### PR TITLE
update IPs to the currently installed Vivado version

### DIFF
--- a/pciescreamer/vivado_generate_project.tcl
+++ b/pciescreamer/vivado_generate_project.tcl
@@ -674,6 +674,8 @@ set_property -name "xsim.simulate.xsim.more_options" -value "" -objects $obj
 
 # Adding sources referenced in BDs, if not already added
 
+# Upgrade IP from the currently installed Vivado version
+upgrade_ip [get_ips *]
 
 # Proc to create BD pcileech_vfifo
 proc cr_bd_pcileech_vfifo { parentCell } {


### PR DESCRIPTION
When using a Vivado version greater than the one used to generate the
project previously, warnings appear when building the project:

source vivado_generate_project.tcl -notrace
INFO: [IP_Flow 19-234] Refreshing IP repositories
INFO: [IP_Flow 19-1704] No user IP repositories specified
INFO: [IP_Flow 19-2313] Loaded Vivado IP repository '/opt/Xilinx/Vivado/2018.3/data/ip'.
WARNING: [IP_Flow 19-2162] IP 'pcie_7x_0' is locked:
* IP definition '7 Series Integrated Block for PCI Express (3.3)' for IP 'pcie_7x_0' (customized with software release 2018.2.1) has a different revision in the IP Catalog.
Please select 'Report IP Status' from the 'Tools/Report' menu or run Tcl command 'report_ip_status' for more information.

(this warning repeats for all IPs).

The upgrade_ip command updates the parts and seems to fix the warning.