### PR TITLE
fix: split completion lower addr and x1 tx reset signal

### DIFF
--- a/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;      // only first completion carries original lower addr (PCIe spec)
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;      // only first completion carries original lower addr (PCIe spec)
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;      // only first completion carries original lower addr (PCIe spec)
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;      // only first completion carries original lower addr (PCIe spec)
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;      // only first completion carries original lower addr (PCIe spec)
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     


### PR DESCRIPTION
two small fixes across all CaptainDMA variants:

**bar controller - split completion lower address**

per the pcie spec, only the first completion in a split transaction carries the original lower address. the rest should be zero. it was sending the original address on every completion. now it only carries through on the first one.

**x1 - tlp tx datapath reset**

on x1 boards the TLP sink module was only using the global `rst` signal, missing the link reset (`rst_pcie_user`). switched to `rst_subsys` so link resets actually clear the tx pipeline. x4 was already correct.