### PR TITLE
hda sound card support and bar controller fixes

### DIFF
--- a/CaptainDMA/100t484-1/src/pcileech_100t484_x1_top.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_100t484_x1_top.sv
@@ -13,7 +13,7 @@
 module pcileech_100t484_x1_top #(
     parameter       PARAM_DEVICE_ID = 9,
     parameter       PARAM_VERSION_NUMBER_MAJOR = 4,
-    parameter       PARAM_VERSION_NUMBER_MINOR = 14,
+    parameter       PARAM_VERSION_NUMBER_MINOR = 18,
     parameter       PARAM_CUSTOM_VALUE = 32'hffffffff
 ) (
     // SYS

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
@@ -96,11 +96,15 @@ module pcileech_pcie_a7(
         .clk_pcie                   ( clk_pcie                  ),
         .clk_sys                    ( clk_sys                   ),
         .dfifo                      ( dfifo_tlp                 ),
-        .tlps_tx                    ( tlps_tx.source            ),       
+        .tlps_tx                    ( tlps_tx.source            ),
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        // HDA MSI interrupt
+        .cfg_interrupt              ( ctx.cfg_interrupt         ),
+        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
+        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
@@ -46,6 +46,8 @@ module pcileech_pcie_a7(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;            // interrupt request pulse from TLP to CFG
+    wire [7:0]              intr_msi_data = 8'h00; // MSI message data (tied to 0; MSI payload from config space)
     
     // system interface
     wire pcie_clk_c;
@@ -78,7 +80,8 @@ module pcileech_pcie_a7(
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
         .pcie_id                    ( pcie_id                   ),   // -> [15:0]
-        .intr_req                   ( intr_req                  )
+        .intr_req                   ( intr_req                  ),
+        .intr_msi_data              ( intr_msi_data             )
     );
     
     // ----------------------------------------------------------------------------
@@ -91,8 +94,6 @@ module pcileech_pcie_a7(
         .tlp_rx                     ( tlp_rx.sink               ),
         .tlps_out                   ( tlps_rx.source_lite       )
     );
-    
-    wire intr_req;
 
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
@@ -74,10 +74,11 @@ module pcileech_pcie_a7(
         .rst                        ( rst_subsys                ),
         .clk_sys                    ( clk_sys                   ),
         .clk_pcie                   ( clk_pcie                  ),
-        .dfifo                      ( dfifo_cfg                 ),        
+        .dfifo                      ( dfifo_cfg                 ),
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -91,6 +92,8 @@ module pcileech_pcie_a7(
         .tlps_out                   ( tlps_rx.source_lite       )
     );
     
+    wire intr_req;
+
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
@@ -101,10 +104,7 @@ module pcileech_pcie_a7(
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
         .pcie_id                    ( pcie_id                   ),   // <- [15:0]
-        // HDA MSI interrupt
-        .cfg_interrupt              ( ctx.cfg_interrupt         ),
-        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
-        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_a7.sv
@@ -47,7 +47,6 @@ module pcileech_pcie_a7(
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
     wire                    intr_req;            // interrupt request pulse from TLP to CFG
-    wire [7:0]              intr_msi_data = 8'h00; // MSI message data (tied to 0; MSI payload from config space)
     
     // system interface
     wire pcie_clk_c;
@@ -80,8 +79,7 @@ module pcileech_pcie_a7(
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
         .pcie_id                    ( pcie_id                   ),   // -> [15:0]
-        .intr_req                   ( intr_req                  ),
-        .intr_msi_data              ( intr_msi_data             )
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -38,11 +38,6 @@ module pcileech_pcie_cfg_a7(
     wire            in_empty;
     wire            in_valid;
     
-    reg [63:0]      in_data64;
-    wire [31:0]     in_data32   = in_data64[63:32];
-    wire [15:0]     in_data16   = in_data64[31:16];
-    wire [3:0]      in_type     = in_data64[15:12];
-	
     fifo_64_64 i_fifo_pcie_cfg_tx(
         .rst            ( rst                   ),
         .wr_clk         ( clk_sys               ),

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -280,7 +281,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt                = rw[206] | intr_req;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -91,6 +91,10 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+
+    // interrupt request latch: hold intr_req pulse until cfg_interrupt_rdy
+    // is asserted, preventing interrupt loss when PCIe core is busy.
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -273,10 +277,23 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    // Latch intr_req pulse and hold until cfg_interrupt_rdy asserts.
+    // Xilinx PCIe core expects cfg_interrupt to remain asserted until rdy.
+    // Without this, a 1-cycle intr_req pulse during rdy=0 is lost forever.
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;  // core accepted, clear latch
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;  // new request, set latch
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206] | intr_req;
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -314,7 +314,7 @@ module pcileech_pcie_cfg_a7(
     // STATE MACHINE / LOGIC FOR READ/WRITE AND OTHER HOUSEKEEPING TASKS
     // ------------------------------------------------------------------------
     
-    integer i_write, i_tlpstatic;
+    integer i_write;
     wire [15:0] in_cmd_address_byte = in_dout[31:16];
     wire [17:0] in_cmd_address_bit  = {in_cmd_address_byte[14:0], 3'b000};
     wire [15:0] in_cmd_value        = {in_dout[48+:8], in_dout[56+:8]};

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -18,8 +18,7 @@ module pcileech_pcie_cfg_a7(
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
     output [15:0]           pcie_id,
-    input                   intr_req,
-    input  [7:0]            intr_msi_data
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -96,11 +95,11 @@ module pcileech_pcie_cfg_a7(
     // interrupt request latch: hold intr_req pulse until cfg_interrupt_rdy
     // is asserted, preventing interrupt loss when PCIe core is busy.
     reg                 intr_req_pending;
-   
+
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
     // ------------------------------------------------------------------------
-     
+
     // MAGIC
     assign ro[15:0]     = 16'h2301;                     // +000: MAGIC
     // SPECIAL
@@ -291,12 +290,7 @@ module pcileech_pcie_cfg_a7(
         end
     end
 
-    // MSI message data from BAR controller (wired to intr_msi_data port).
-    // This carries the host-programmed MSI data value that the PCIe core
-    // uses as the MSI message payload when an interrupt is asserted.
-    wire [7:0] cfg_interrupt_do = intr_msi_data;
-
-    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
+    assign ctx.cfg_interrupt_di             = ctx.cfg_interrupt_do;  // use host-programmed MSI data from PCIe core
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
     assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -273,7 +273,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
-    assign ctx.cfg_interrupt_di             = rw[199:192];
+    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
     assign ctx.cfg_interrupt                = rw[206] | intr_req;

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -18,7 +18,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
     output [15:0]           pcie_id,
-    input                   intr_req
+    input                   intr_req,
+    input  [7:0]            intr_msi_data
     );
 
     // ----------------------------------------------------
@@ -289,6 +290,11 @@ module pcileech_pcie_cfg_a7(
             intr_req_pending <= 1'b1;  // new request, set latch
         end
     end
+
+    // MSI message data from BAR controller (wired to intr_msi_data port).
+    // This carries the host-programmed MSI data value that the PCIe core
+    // uses as the MSI message payload when an interrupt is asserted.
+    wire [7:0] cfg_interrupt_do = intr_msi_data;
 
     assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_tlp_a7.sv
@@ -21,24 +21,31 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
     );
-    
+
     IfAXIS128 tlps_bar_rsp();
     IfAXIS128 tlps_cfg_rsp();
-    
+
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards:
     // ------------------------------------------------------------------------
     IfAXIS128 tlps_filtered();
-    
+
     pcileech_tlps128_bar_controller i_pcileech_tlps128_bar_controller(
-        .rst            ( rst                           ),
-        .clk            ( clk_pcie                      ),
-        .bar_en         ( dshadow2fifo.bar_en           ),
-        .pcie_id        ( pcie_id                       ),
-        .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .rst                ( rst                           ),
+        .clk                ( clk_pcie                      ),
+        .bar_en             ( dshadow2fifo.bar_en           ),
+        .pcie_id            ( pcie_id                       ),
+        .tlps_in            ( tlps_rx                       ),
+        .tlps_out           ( tlps_bar_rsp.source           ),
+        .cfg_interrupt      ( cfg_interrupt                 ),
+        .cfg_interrupt_assert( cfg_interrupt_assert         ),
+        .cfg_interrupt_di   ( cfg_interrupt_di              )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_tlp_a7.sv
@@ -22,10 +22,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
     input [15:0]            pcie_id,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
     );
 
     IfAXIS128 tlps_bar_rsp();
@@ -43,9 +41,7 @@ module pcileech_pcie_tlp_a7(
         .pcie_id            ( pcie_id                       ),
         .tlps_in            ( tlps_rx                       ),
         .tlps_out           ( tlps_bar_rsp.source           ),
-        .cfg_interrupt      ( cfg_interrupt                 ),
-        .cfg_interrupt_assert( cfg_interrupt_assert         ),
-        .cfg_interrupt_di   ( cfg_interrupt_di              )
+        .intr_req           ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
@@ -45,9 +45,18 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
 );
-    
+
+    // HDA MSI interrupt defaults (idle)
+    assign cfg_interrupt        = 1'b0;
+    assign cfg_interrupt_assert = 1'b0;
+    assign cfg_interrupt_di     = 8'h0;
+
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
     // Receive incoming BAR requests from the TLP stream:

--- a/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
@@ -46,16 +46,12 @@ module pcileech_tlps128_bar_controller(
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
     IfAXIS128.source        tlps_out,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
 );
 
-    // HDA MSI interrupt defaults (idle)
-    assign cfg_interrupt        = 1'b0;
-    assign cfg_interrupt_assert = 1'b0;
-    assign cfg_interrupt_di     = 8'h0;
+    // HDA MSI interrupt request defaults (idle)
+    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:

--- a/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
@@ -50,8 +50,6 @@ module pcileech_tlps128_bar_controller(
     output                  intr_req
 );
 
-    // HDA MSI interrupt request defaults (idle)
-    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
@@ -85,6 +83,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -151,7 +152,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -166,10 +168,11 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    pcileech_bar_impl_msi i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -181,7 +184,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -196,7 +200,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -211,7 +216,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -226,7 +232,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -241,7 +248,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -695,8 +703,11 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
@@ -727,8 +738,11 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]      rd_req_ctx_1;
     bit [31:0]      rd_req_addr_1;
@@ -766,8 +780,11 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]  drd_req_ctx;
     bit         drd_req_valid;
@@ -794,5 +811,70 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+endmodule
+
+
+// ------------------------------------------------------------------------
+// BAR implementation: MSI doorbell interrupt generator.
+// Write to offset 0x00 to trigger an MSI interrupt (the written value is
+// the MSI vector/data). Read offset 0x00 to read back the last written
+// value. This allows software to configure and verify the interrupt path.
+// Latency = 2CLKs (matches loopaddr/zerowrite4k for pipeline consistency).
+// ------------------------------------------------------------------------
+module pcileech_bar_impl_msi(
+    input               rst,
+    input               clk,
+    // incoming BAR writes:
+    input [31:0]        wr_addr,
+    input [3:0]         wr_be,
+    input [31:0]        wr_data,
+    input               wr_valid,
+    // incoming BAR reads:
+    input  [87:0]       rd_req_ctx,
+    input  [31:0]       rd_req_addr,
+    input               rd_req_valid,
+    // outgoing BAR read replies:
+    output bit [87:0]   rd_rsp_ctx,
+    output bit [31:0]   rd_rsp_data,
+    output bit          rd_rsp_valid,
+    // MSI interrupt request
+    output              intr_req
+);
+
+    bit [31:0]      doorbell;
+    bit             intr_req_reg;
+    bit [31:0]      doorbell_q;
+    bit             rd_req_valid_q;
+
+    // 2-cycle latency for reads (matches other BAR impls)
+    always @ ( posedge clk ) begin
+        doorbell_q          <= doorbell;
+        rd_req_valid_q      <= rd_req_valid;
+        rd_rsp_ctx          <= rd_req_ctx;
+        rd_rsp_data         <= doorbell_q;
+        rd_rsp_valid        <= rd_req_valid_q;
+    end
+
+    // Doorbell register: write updates value and triggers interrupt pulse
+    always @ ( posedge clk ) begin
+        if ( rst ) begin
+            doorbell    <= 32'h0;
+            intr_req_reg <= 1'b0;
+        end
+        else if ( wr_valid ) begin
+            // Apply byte enables
+            if ( wr_be[0] ) doorbell[7:0]   <= wr_data[7:0];
+            if ( wr_be[1] ) doorbell[15:8]  <= wr_data[15:8];
+            if ( wr_be[2] ) doorbell[23:16] <= wr_data[23:16];
+            if ( wr_be[3] ) doorbell[31:24] <= wr_data[31:24];
+            intr_req_reg <= 1'b1;
+        end
+        else begin
+            intr_req_reg <= 1'b0;
+        end
+    end
+
+    assign intr_req = intr_req_reg;
 
 endmodule

--- a/CaptainDMA/35t325_x1/src/pcileech_35t325_x1_top.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_35t325_x1_top.sv
@@ -13,7 +13,7 @@
 module pcileech_35t325_x1_top #(
     parameter       PARAM_DEVICE_ID = 4,
     parameter       PARAM_VERSION_NUMBER_MAJOR = 4,
-    parameter       PARAM_VERSION_NUMBER_MINOR = 14,
+    parameter       PARAM_VERSION_NUMBER_MINOR = 18,
     parameter       PARAM_CUSTOM_VALUE = 32'hffffffff
 ) (
     // SYS

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
@@ -96,11 +96,15 @@ module pcileech_pcie_a7(
         .clk_pcie                   ( clk_pcie                  ),
         .clk_sys                    ( clk_sys                   ),
         .dfifo                      ( dfifo_tlp                 ),
-        .tlps_tx                    ( tlps_tx.source            ),       
+        .tlps_tx                    ( tlps_tx.source            ),
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        // HDA MSI interrupt
+        .cfg_interrupt              ( ctx.cfg_interrupt         ),
+        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
+        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
@@ -74,10 +74,11 @@ module pcileech_pcie_a7(
         .rst                        ( rst_subsys                ),
         .clk_sys                    ( clk_sys                   ),
         .clk_pcie                   ( clk_pcie                  ),
-        .dfifo                      ( dfifo_cfg                 ),        
+        .dfifo                      ( dfifo_cfg                 ),
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -91,6 +92,8 @@ module pcileech_pcie_a7(
         .tlps_out                   ( tlps_rx.source_lite       )
     );
     
+    wire intr_req;
+
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
@@ -101,10 +104,7 @@ module pcileech_pcie_a7(
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
         .pcie_id                    ( pcie_id                   ),   // <- [15:0]
-        // HDA MSI interrupt
-        .cfg_interrupt              ( ctx.cfg_interrupt         ),
-        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
-        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_a7.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;            // interrupt request pulse from TLP to CFG
     
     // system interface
     wire pcie_clk_c;
@@ -91,8 +92,6 @@ module pcileech_pcie_a7(
         .tlp_rx                     ( tlp_rx.sink               ),
         .tlps_out                   ( tlps_rx.source_lite       )
     );
-    
-    wire intr_req;
 
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
@@ -38,11 +38,6 @@ module pcileech_pcie_cfg_a7(
     wire            in_empty;
     wire            in_valid;
     
-    reg [63:0]      in_data64;
-    wire [31:0]     in_data32   = in_data64[63:32];
-    wire [15:0]     in_data16   = in_data64[31:16];
-    wire [3:0]      in_type     = in_data64[15:12];
-	
     fifo_64_64 i_fifo_pcie_cfg_tx(
         .rst            ( rst                   ),
         .wr_clk         ( clk_sys               ),

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -280,7 +281,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt                = rw[206] | intr_req;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
@@ -290,7 +290,7 @@ module pcileech_pcie_cfg_a7(
         end
     end
 
-    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
+    assign ctx.cfg_interrupt_di             = ctx.cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
     assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
@@ -91,6 +91,10 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+
+    // interrupt request latch: hold intr_req pulse until cfg_interrupt_rdy
+    // is asserted, preventing interrupt loss when PCIe core is busy.
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -273,10 +277,23 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    // Latch intr_req pulse and hold until cfg_interrupt_rdy asserts.
+    // Xilinx PCIe core expects cfg_interrupt to remain asserted until rdy.
+    // Without this, a 1-cycle intr_req pulse during rdy=0 is lost forever.
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;  // core accepted, clear latch
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;  // new request, set latch
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206] | intr_req;
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
@@ -314,7 +314,7 @@ module pcileech_pcie_cfg_a7(
     // STATE MACHINE / LOGIC FOR READ/WRITE AND OTHER HOUSEKEEPING TASKS
     // ------------------------------------------------------------------------
     
-    integer i_write, i_tlpstatic;
+    integer i_write;
     wire [15:0] in_cmd_address_byte = in_dout[31:16];
     wire [17:0] in_cmd_address_bit  = {in_cmd_address_byte[14:0], 3'b000};
     wire [15:0] in_cmd_value        = {in_dout[48+:8], in_dout[56+:8]};

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
@@ -273,7 +273,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
-    assign ctx.cfg_interrupt_di             = rw[199:192];
+    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
     assign ctx.cfg_interrupt                = rw[206] | intr_req;

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_tlp_a7.sv
@@ -21,24 +21,31 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
     );
-    
+
     IfAXIS128 tlps_bar_rsp();
     IfAXIS128 tlps_cfg_rsp();
-    
+
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards:
     // ------------------------------------------------------------------------
     IfAXIS128 tlps_filtered();
-    
+
     pcileech_tlps128_bar_controller i_pcileech_tlps128_bar_controller(
-        .rst            ( rst                           ),
-        .clk            ( clk_pcie                      ),
-        .bar_en         ( dshadow2fifo.bar_en           ),
-        .pcie_id        ( pcie_id                       ),
-        .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .rst                ( rst                           ),
+        .clk                ( clk_pcie                      ),
+        .bar_en             ( dshadow2fifo.bar_en           ),
+        .pcie_id            ( pcie_id                       ),
+        .tlps_in            ( tlps_rx                       ),
+        .tlps_out           ( tlps_bar_rsp.source           ),
+        .cfg_interrupt      ( cfg_interrupt                 ),
+        .cfg_interrupt_assert( cfg_interrupt_assert         ),
+        .cfg_interrupt_di   ( cfg_interrupt_di              )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_tlp_a7.sv
@@ -22,10 +22,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
     input [15:0]            pcie_id,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
     );
 
     IfAXIS128 tlps_bar_rsp();
@@ -43,9 +41,7 @@ module pcileech_pcie_tlp_a7(
         .pcie_id            ( pcie_id                       ),
         .tlps_in            ( tlps_rx                       ),
         .tlps_out           ( tlps_bar_rsp.source           ),
-        .cfg_interrupt      ( cfg_interrupt                 ),
-        .cfg_interrupt_assert( cfg_interrupt_assert         ),
-        .cfg_interrupt_di   ( cfg_interrupt_di              )
+        .intr_req           ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
@@ -45,9 +45,18 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
 );
-    
+
+    // HDA MSI interrupt defaults (idle)
+    assign cfg_interrupt        = 1'b0;
+    assign cfg_interrupt_assert = 1'b0;
+    assign cfg_interrupt_di     = 8'h0;
+
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
     // Receive incoming BAR requests from the TLP stream:

--- a/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
@@ -46,16 +46,12 @@ module pcileech_tlps128_bar_controller(
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
     IfAXIS128.source        tlps_out,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
 );
 
-    // HDA MSI interrupt defaults (idle)
-    assign cfg_interrupt        = 1'b0;
-    assign cfg_interrupt_assert = 1'b0;
-    assign cfg_interrupt_di     = 8'h0;
+    // HDA MSI interrupt request defaults (idle)
+    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:

--- a/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
@@ -50,8 +50,6 @@ module pcileech_tlps128_bar_controller(
     output                  intr_req
 );
 
-    // HDA MSI interrupt request defaults (idle)
-    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
@@ -85,6 +83,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -151,7 +152,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -166,10 +168,11 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    pcileech_bar_impl_msi i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -181,7 +184,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -196,7 +200,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -211,7 +216,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -226,7 +232,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -241,7 +248,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -695,8 +703,11 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
@@ -727,8 +738,11 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]      rd_req_ctx_1;
     bit [31:0]      rd_req_addr_1;
@@ -766,8 +780,11 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]  drd_req_ctx;
     bit         drd_req_valid;
@@ -794,5 +811,70 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+endmodule
+
+
+// ------------------------------------------------------------------------
+// BAR implementation: MSI doorbell interrupt generator.
+// Write to offset 0x00 to trigger an MSI interrupt (the written value is
+// the MSI vector/data). Read offset 0x00 to read back the last written
+// value. This allows software to configure and verify the interrupt path.
+// Latency = 2CLKs (matches loopaddr/zerowrite4k for pipeline consistency).
+// ------------------------------------------------------------------------
+module pcileech_bar_impl_msi(
+    input               rst,
+    input               clk,
+    // incoming BAR writes:
+    input [31:0]        wr_addr,
+    input [3:0]         wr_be,
+    input [31:0]        wr_data,
+    input               wr_valid,
+    // incoming BAR reads:
+    input  [87:0]       rd_req_ctx,
+    input  [31:0]       rd_req_addr,
+    input               rd_req_valid,
+    // outgoing BAR read replies:
+    output bit [87:0]   rd_rsp_ctx,
+    output bit [31:0]   rd_rsp_data,
+    output bit          rd_rsp_valid,
+    // MSI interrupt request
+    output              intr_req
+);
+
+    bit [31:0]      doorbell;
+    bit             intr_req_reg;
+    bit [31:0]      doorbell_q;
+    bit             rd_req_valid_q;
+
+    // 2-cycle latency for reads (matches other BAR impls)
+    always @ ( posedge clk ) begin
+        doorbell_q          <= doorbell;
+        rd_req_valid_q      <= rd_req_valid;
+        rd_rsp_ctx          <= rd_req_ctx;
+        rd_rsp_data         <= doorbell_q;
+        rd_rsp_valid        <= rd_req_valid_q;
+    end
+
+    // Doorbell register: write updates value and triggers interrupt pulse
+    always @ ( posedge clk ) begin
+        if ( rst ) begin
+            doorbell    <= 32'h0;
+            intr_req_reg <= 1'b0;
+        end
+        else if ( wr_valid ) begin
+            // Apply byte enables
+            if ( wr_be[0] ) doorbell[7:0]   <= wr_data[7:0];
+            if ( wr_be[1] ) doorbell[15:8]  <= wr_data[15:8];
+            if ( wr_be[2] ) doorbell[23:16] <= wr_data[23:16];
+            if ( wr_be[3] ) doorbell[31:24] <= wr_data[31:24];
+            intr_req_reg <= 1'b1;
+        end
+        else begin
+            intr_req_reg <= 1'b0;
+        end
+    end
+
+    assign intr_req = intr_req_reg;
 
 endmodule

--- a/CaptainDMA/35t325_x4/src/pcileech_35t325_x4_top.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_35t325_x4_top.sv
@@ -13,7 +13,7 @@
 module pcileech_35t325_x4_top #(
     parameter       PARAM_DEVICE_ID = 4,
     parameter       PARAM_VERSION_NUMBER_MAJOR = 4,
-    parameter       PARAM_VERSION_NUMBER_MINOR = 15,
+    parameter       PARAM_VERSION_NUMBER_MINOR = 18,
     parameter       PARAM_CUSTOM_VALUE = 32'hffffffff
 ) (
     // SYS

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_a7x4.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_a7x4.sv
@@ -341,7 +341,6 @@ module pcileech_tlps128_src128(
     wire [1:0]      rxf_eof_dw      = rxf_user[20:19];
     wire [6:0]      rxf_bar_hit     = rxf_user[8:2];
     
-    wire [3:0]      rx_keep_dw; 
     
     assign rxf_ready = !(rxd_valid && rxf_eof && (rxf_eof_dw >= 2)) || !rxf_valid;
     

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_a7x4.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_a7x4.sv
@@ -74,10 +74,11 @@ module pcileech_pcie_a7x4(
         .rst                        ( rst_subsys                ),
         .clk_sys                    ( clk_sys                   ),
         .clk_pcie                   ( clk_pcie                  ),
-        .dfifo                      ( dfifo_cfg                 ),        
+        .dfifo                      ( dfifo_cfg                 ),
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -91,6 +92,8 @@ module pcileech_pcie_a7x4(
         .tlps_out                   ( tlps_rx.source_lite       )
     );
     
+    wire intr_req;
+
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
@@ -100,7 +103,8 @@ module pcileech_pcie_a7x4(
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst128 i_pcileech_tlps128_dst128(

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_a7x4.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_a7x4.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7x4(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;            // interrupt request pulse from TLP to CFG
     
     // system interface
     wire pcie_clk_c;
@@ -91,8 +92,6 @@ module pcileech_pcie_a7x4(
         .tlp_rx                     ( tlp_rx.sink               ),
         .tlps_out                   ( tlps_rx.source_lite       )
     );
-    
-    wire intr_req;
 
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
@@ -38,11 +38,6 @@ module pcileech_pcie_cfg_a7(
     wire            in_empty;
     wire            in_valid;
     
-    reg [63:0]      in_data64;
-    wire [31:0]     in_data32   = in_data64[63:32];
-    wire [15:0]     in_data16   = in_data64[31:16];
-    wire [3:0]      in_type     = in_data64[15:12];
-	
     fifo_64_64 i_fifo_pcie_cfg_tx(
         .rst            ( rst                   ),
         .wr_clk         ( clk_sys               ),

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -280,7 +281,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt                = rw[206] | intr_req;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
@@ -290,7 +290,7 @@ module pcileech_pcie_cfg_a7(
         end
     end
 
-    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
+    assign ctx.cfg_interrupt_di             = ctx.cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
     assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
@@ -91,6 +91,10 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+
+    // interrupt request latch: hold intr_req pulse until cfg_interrupt_rdy
+    // is asserted, preventing interrupt loss when PCIe core is busy.
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -273,10 +277,23 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    // Latch intr_req pulse and hold until cfg_interrupt_rdy asserts.
+    // Xilinx PCIe core expects cfg_interrupt to remain asserted until rdy.
+    // Without this, a 1-cycle intr_req pulse during rdy=0 is lost forever.
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;  // core accepted, clear latch
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;  // new request, set latch
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206] | intr_req;
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
@@ -314,7 +314,7 @@ module pcileech_pcie_cfg_a7(
     // STATE MACHINE / LOGIC FOR READ/WRITE AND OTHER HOUSEKEEPING TASKS
     // ------------------------------------------------------------------------
     
-    integer i_write, i_tlpstatic;
+    integer i_write;
     wire [15:0] in_cmd_address_byte = in_dout[31:16];
     wire [17:0] in_cmd_address_bit  = {in_cmd_address_byte[14:0], 3'b000};
     wire [15:0] in_cmd_value        = {in_dout[48+:8], in_dout[56+:8]};

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
@@ -273,7 +273,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
-    assign ctx.cfg_interrupt_di             = rw[199:192];
+    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
     assign ctx.cfg_interrupt                = rw[206] | intr_req;

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_tlp_a7.sv
@@ -21,24 +21,31 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
     );
-    
+
     IfAXIS128 tlps_bar_rsp();
     IfAXIS128 tlps_cfg_rsp();
-    
+
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards:
     // ------------------------------------------------------------------------
     IfAXIS128 tlps_filtered();
-    
+
     pcileech_tlps128_bar_controller i_pcileech_tlps128_bar_controller(
-        .rst            ( rst                           ),
-        .clk            ( clk_pcie                      ),
-        .bar_en         ( dshadow2fifo.bar_en           ),
-        .pcie_id        ( pcie_id                       ),
-        .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .rst                ( rst                           ),
+        .clk                ( clk_pcie                      ),
+        .bar_en             ( dshadow2fifo.bar_en           ),
+        .pcie_id            ( pcie_id                       ),
+        .tlps_in            ( tlps_rx                       ),
+        .tlps_out           ( tlps_bar_rsp.source           ),
+        .cfg_interrupt      ( cfg_interrupt                 ),
+        .cfg_interrupt_assert( cfg_interrupt_assert         ),
+        .cfg_interrupt_di   ( cfg_interrupt_di              )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_tlp_a7.sv
@@ -22,10 +22,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
     input [15:0]            pcie_id,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
     );
 
     IfAXIS128 tlps_bar_rsp();
@@ -43,9 +41,7 @@ module pcileech_pcie_tlp_a7(
         .pcie_id            ( pcie_id                       ),
         .tlps_in            ( tlps_rx                       ),
         .tlps_out           ( tlps_bar_rsp.source           ),
-        .cfg_interrupt      ( cfg_interrupt                 ),
-        .cfg_interrupt_assert( cfg_interrupt_assert         ),
-        .cfg_interrupt_di   ( cfg_interrupt_di              )
+        .intr_req           ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
@@ -45,9 +45,18 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
 );
-    
+
+    // HDA MSI interrupt defaults (idle)
+    assign cfg_interrupt        = 1'b0;
+    assign cfg_interrupt_assert = 1'b0;
+    assign cfg_interrupt_di     = 8'h0;
+
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
     // Receive incoming BAR requests from the TLP stream:

--- a/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
@@ -46,16 +46,12 @@ module pcileech_tlps128_bar_controller(
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
     IfAXIS128.source        tlps_out,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
 );
 
-    // HDA MSI interrupt defaults (idle)
-    assign cfg_interrupt        = 1'b0;
-    assign cfg_interrupt_assert = 1'b0;
-    assign cfg_interrupt_di     = 8'h0;
+    // HDA MSI interrupt request defaults (idle)
+    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:

--- a/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
@@ -50,8 +50,6 @@ module pcileech_tlps128_bar_controller(
     output                  intr_req
 );
 
-    // HDA MSI interrupt request defaults (idle)
-    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
@@ -85,6 +83,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -151,7 +152,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -166,10 +168,11 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    pcileech_bar_impl_msi i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -181,7 +184,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -196,7 +200,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -211,7 +216,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -226,7 +232,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -241,7 +248,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -695,8 +703,11 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
@@ -727,8 +738,11 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]      rd_req_ctx_1;
     bit [31:0]      rd_req_addr_1;
@@ -766,8 +780,11 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]  drd_req_ctx;
     bit         drd_req_valid;
@@ -794,5 +811,70 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+endmodule
+
+
+// ------------------------------------------------------------------------
+// BAR implementation: MSI doorbell interrupt generator.
+// Write to offset 0x00 to trigger an MSI interrupt (the written value is
+// the MSI vector/data). Read offset 0x00 to read back the last written
+// value. This allows software to configure and verify the interrupt path.
+// Latency = 2CLKs (matches loopaddr/zerowrite4k for pipeline consistency).
+// ------------------------------------------------------------------------
+module pcileech_bar_impl_msi(
+    input               rst,
+    input               clk,
+    // incoming BAR writes:
+    input [31:0]        wr_addr,
+    input [3:0]         wr_be,
+    input [31:0]        wr_data,
+    input               wr_valid,
+    // incoming BAR reads:
+    input  [87:0]       rd_req_ctx,
+    input  [31:0]       rd_req_addr,
+    input               rd_req_valid,
+    // outgoing BAR read replies:
+    output bit [87:0]   rd_rsp_ctx,
+    output bit [31:0]   rd_rsp_data,
+    output bit          rd_rsp_valid,
+    // MSI interrupt request
+    output              intr_req
+);
+
+    bit [31:0]      doorbell;
+    bit             intr_req_reg;
+    bit [31:0]      doorbell_q;
+    bit             rd_req_valid_q;
+
+    // 2-cycle latency for reads (matches other BAR impls)
+    always @ ( posedge clk ) begin
+        doorbell_q          <= doorbell;
+        rd_req_valid_q      <= rd_req_valid;
+        rd_rsp_ctx          <= rd_req_ctx;
+        rd_rsp_data         <= doorbell_q;
+        rd_rsp_valid        <= rd_req_valid_q;
+    end
+
+    // Doorbell register: write updates value and triggers interrupt pulse
+    always @ ( posedge clk ) begin
+        if ( rst ) begin
+            doorbell    <= 32'h0;
+            intr_req_reg <= 1'b0;
+        end
+        else if ( wr_valid ) begin
+            // Apply byte enables
+            if ( wr_be[0] ) doorbell[7:0]   <= wr_data[7:0];
+            if ( wr_be[1] ) doorbell[15:8]  <= wr_data[15:8];
+            if ( wr_be[2] ) doorbell[23:16] <= wr_data[23:16];
+            if ( wr_be[3] ) doorbell[31:24] <= wr_data[31:24];
+            intr_req_reg <= 1'b1;
+        end
+        else begin
+            intr_req_reg <= 1'b0;
+        end
+    end
+
+    assign intr_req = intr_req_reg;
 
 endmodule

--- a/CaptainDMA/35t484_x1/src/pcileech_35t484_x1_top.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_35t484_x1_top.sv
@@ -13,7 +13,7 @@
 module pcileech_35t484_x1_top #(
     parameter       PARAM_DEVICE_ID = 12,
     parameter       PARAM_VERSION_NUMBER_MAJOR = 4,
-    parameter       PARAM_VERSION_NUMBER_MINOR = 14,
+    parameter       PARAM_VERSION_NUMBER_MINOR = 18,
     parameter       PARAM_CUSTOM_VALUE = 32'hffffffff
 ) (
     // SYS

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
@@ -96,11 +96,15 @@ module pcileech_pcie_a7(
         .clk_pcie                   ( clk_pcie                  ),
         .clk_sys                    ( clk_sys                   ),
         .dfifo                      ( dfifo_tlp                 ),
-        .tlps_tx                    ( tlps_tx.source            ),       
+        .tlps_tx                    ( tlps_tx.source            ),
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        // HDA MSI interrupt
+        .cfg_interrupt              ( ctx.cfg_interrupt         ),
+        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
+        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
@@ -74,10 +74,11 @@ module pcileech_pcie_a7(
         .rst                        ( rst_subsys                ),
         .clk_sys                    ( clk_sys                   ),
         .clk_pcie                   ( clk_pcie                  ),
-        .dfifo                      ( dfifo_cfg                 ),        
+        .dfifo                      ( dfifo_cfg                 ),
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -91,6 +92,8 @@ module pcileech_pcie_a7(
         .tlps_out                   ( tlps_rx.source_lite       )
     );
     
+    wire intr_req;
+
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
@@ -101,10 +104,7 @@ module pcileech_pcie_a7(
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
         .pcie_id                    ( pcie_id                   ),   // <- [15:0]
-        // HDA MSI interrupt
-        .cfg_interrupt              ( ctx.cfg_interrupt         ),
-        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
-        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_a7.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;            // interrupt request pulse from TLP to CFG
     
     // system interface
     wire pcie_clk_c;
@@ -91,8 +92,6 @@ module pcileech_pcie_a7(
         .tlp_rx                     ( tlp_rx.sink               ),
         .tlps_out                   ( tlps_rx.source_lite       )
     );
-    
-    wire intr_req;
 
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -38,11 +38,6 @@ module pcileech_pcie_cfg_a7(
     wire            in_empty;
     wire            in_valid;
     
-    reg [63:0]      in_data64;
-    wire [31:0]     in_data32   = in_data64[63:32];
-    wire [15:0]     in_data16   = in_data64[31:16];
-    wire [3:0]      in_type     = in_data64[15:12];
-	
     fifo_64_64 i_fifo_pcie_cfg_tx(
         .rst            ( rst                   ),
         .wr_clk         ( clk_sys               ),

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -280,7 +281,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt                = rw[206] | intr_req;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -290,7 +290,7 @@ module pcileech_pcie_cfg_a7(
         end
     end
 
-    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
+    assign ctx.cfg_interrupt_di             = ctx.cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
     assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -91,6 +91,10 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+
+    // interrupt request latch: hold intr_req pulse until cfg_interrupt_rdy
+    // is asserted, preventing interrupt loss when PCIe core is busy.
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -273,10 +277,23 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    // Latch intr_req pulse and hold until cfg_interrupt_rdy asserts.
+    // Xilinx PCIe core expects cfg_interrupt to remain asserted until rdy.
+    // Without this, a 1-cycle intr_req pulse during rdy=0 is lost forever.
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;  // core accepted, clear latch
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;  // new request, set latch
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206] | intr_req;
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -314,7 +314,7 @@ module pcileech_pcie_cfg_a7(
     // STATE MACHINE / LOGIC FOR READ/WRITE AND OTHER HOUSEKEEPING TASKS
     // ------------------------------------------------------------------------
     
-    integer i_write, i_tlpstatic;
+    integer i_write;
     wire [15:0] in_cmd_address_byte = in_dout[31:16];
     wire [17:0] in_cmd_address_bit  = {in_cmd_address_byte[14:0], 3'b000};
     wire [15:0] in_cmd_value        = {in_dout[48+:8], in_dout[56+:8]};

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -273,7 +273,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
-    assign ctx.cfg_interrupt_di             = rw[199:192];
+    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
     assign ctx.cfg_interrupt                = rw[206] | intr_req;

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_tlp_a7.sv
@@ -21,24 +21,31 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
     );
-    
+
     IfAXIS128 tlps_bar_rsp();
     IfAXIS128 tlps_cfg_rsp();
-    
+
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards:
     // ------------------------------------------------------------------------
     IfAXIS128 tlps_filtered();
-    
+
     pcileech_tlps128_bar_controller i_pcileech_tlps128_bar_controller(
-        .rst            ( rst                           ),
-        .clk            ( clk_pcie                      ),
-        .bar_en         ( dshadow2fifo.bar_en           ),
-        .pcie_id        ( pcie_id                       ),
-        .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .rst                ( rst                           ),
+        .clk                ( clk_pcie                      ),
+        .bar_en             ( dshadow2fifo.bar_en           ),
+        .pcie_id            ( pcie_id                       ),
+        .tlps_in            ( tlps_rx                       ),
+        .tlps_out           ( tlps_bar_rsp.source           ),
+        .cfg_interrupt      ( cfg_interrupt                 ),
+        .cfg_interrupt_assert( cfg_interrupt_assert         ),
+        .cfg_interrupt_di   ( cfg_interrupt_di              )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_tlp_a7.sv
@@ -22,10 +22,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
     input [15:0]            pcie_id,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
     );
 
     IfAXIS128 tlps_bar_rsp();
@@ -43,9 +41,7 @@ module pcileech_pcie_tlp_a7(
         .pcie_id            ( pcie_id                       ),
         .tlps_in            ( tlps_rx                       ),
         .tlps_out           ( tlps_bar_rsp.source           ),
-        .cfg_interrupt      ( cfg_interrupt                 ),
-        .cfg_interrupt_assert( cfg_interrupt_assert         ),
-        .cfg_interrupt_di   ( cfg_interrupt_di              )
+        .intr_req           ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -45,9 +45,18 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
 );
-    
+
+    // HDA MSI interrupt defaults (idle)
+    assign cfg_interrupt        = 1'b0;
+    assign cfg_interrupt_assert = 1'b0;
+    assign cfg_interrupt_di     = 8'h0;
+
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
     // Receive incoming BAR requests from the TLP stream:

--- a/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -46,16 +46,12 @@ module pcileech_tlps128_bar_controller(
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
     IfAXIS128.source        tlps_out,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
 );
 
-    // HDA MSI interrupt defaults (idle)
-    assign cfg_interrupt        = 1'b0;
-    assign cfg_interrupt_assert = 1'b0;
-    assign cfg_interrupt_di     = 8'h0;
+    // HDA MSI interrupt request defaults (idle)
+    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:

--- a/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -50,8 +50,6 @@ module pcileech_tlps128_bar_controller(
     output                  intr_req
 );
 
-    // HDA MSI interrupt request defaults (idle)
-    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
@@ -85,6 +83,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -151,7 +152,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -166,10 +168,11 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    pcileech_bar_impl_msi i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -181,7 +184,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -196,7 +200,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -211,7 +216,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -226,7 +232,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -241,7 +248,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -695,8 +703,11 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
@@ -727,8 +738,11 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]      rd_req_ctx_1;
     bit [31:0]      rd_req_addr_1;
@@ -766,8 +780,11 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]  drd_req_ctx;
     bit         drd_req_valid;
@@ -794,5 +811,70 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+endmodule
+
+
+// ------------------------------------------------------------------------
+// BAR implementation: MSI doorbell interrupt generator.
+// Write to offset 0x00 to trigger an MSI interrupt (the written value is
+// the MSI vector/data). Read offset 0x00 to read back the last written
+// value. This allows software to configure and verify the interrupt path.
+// Latency = 2CLKs (matches loopaddr/zerowrite4k for pipeline consistency).
+// ------------------------------------------------------------------------
+module pcileech_bar_impl_msi(
+    input               rst,
+    input               clk,
+    // incoming BAR writes:
+    input [31:0]        wr_addr,
+    input [3:0]         wr_be,
+    input [31:0]        wr_data,
+    input               wr_valid,
+    // incoming BAR reads:
+    input  [87:0]       rd_req_ctx,
+    input  [31:0]       rd_req_addr,
+    input               rd_req_valid,
+    // outgoing BAR read replies:
+    output bit [87:0]   rd_rsp_ctx,
+    output bit [31:0]   rd_rsp_data,
+    output bit          rd_rsp_valid,
+    // MSI interrupt request
+    output              intr_req
+);
+
+    bit [31:0]      doorbell;
+    bit             intr_req_reg;
+    bit [31:0]      doorbell_q;
+    bit             rd_req_valid_q;
+
+    // 2-cycle latency for reads (matches other BAR impls)
+    always @ ( posedge clk ) begin
+        doorbell_q          <= doorbell;
+        rd_req_valid_q      <= rd_req_valid;
+        rd_rsp_ctx          <= rd_req_ctx;
+        rd_rsp_data         <= doorbell_q;
+        rd_rsp_valid        <= rd_req_valid_q;
+    end
+
+    // Doorbell register: write updates value and triggers interrupt pulse
+    always @ ( posedge clk ) begin
+        if ( rst ) begin
+            doorbell    <= 32'h0;
+            intr_req_reg <= 1'b0;
+        end
+        else if ( wr_valid ) begin
+            // Apply byte enables
+            if ( wr_be[0] ) doorbell[7:0]   <= wr_data[7:0];
+            if ( wr_be[1] ) doorbell[15:8]  <= wr_data[15:8];
+            if ( wr_be[2] ) doorbell[23:16] <= wr_data[23:16];
+            if ( wr_be[3] ) doorbell[31:24] <= wr_data[31:24];
+            intr_req_reg <= 1'b1;
+        end
+        else begin
+            intr_req_reg <= 1'b0;
+        end
+    end
+
+    assign intr_req = intr_req_reg;
 
 endmodule

--- a/CaptainDMA/75t484_x1/src/pcileech_75t484_x1_top.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_75t484_x1_top.sv
@@ -13,7 +13,7 @@
 module pcileech_75t484_x1_top #(
     parameter       PARAM_DEVICE_ID = 9,
     parameter       PARAM_VERSION_NUMBER_MAJOR = 4,
-    parameter       PARAM_VERSION_NUMBER_MINOR = 14,
+    parameter       PARAM_VERSION_NUMBER_MINOR = 18,
     parameter       PARAM_CUSTOM_VALUE = 32'hffffffff
 ) (
     // SYS

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
@@ -96,11 +96,15 @@ module pcileech_pcie_a7(
         .clk_pcie                   ( clk_pcie                  ),
         .clk_sys                    ( clk_sys                   ),
         .dfifo                      ( dfifo_tlp                 ),
-        .tlps_tx                    ( tlps_tx.source            ),       
+        .tlps_tx                    ( tlps_tx.source            ),
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        // HDA MSI interrupt
+        .cfg_interrupt              ( ctx.cfg_interrupt         ),
+        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
+        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
@@ -104,7 +104,7 @@ module pcileech_pcie_a7(
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(
-        .rst                        ( rst                       ),
+        .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
         .tlp_tx                     ( tlp_tx.source             ),
         .tlps_in                    ( tlps_tx.sink              )

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
@@ -74,10 +74,11 @@ module pcileech_pcie_a7(
         .rst                        ( rst_subsys                ),
         .clk_sys                    ( clk_sys                   ),
         .clk_pcie                   ( clk_pcie                  ),
-        .dfifo                      ( dfifo_cfg                 ),        
+        .dfifo                      ( dfifo_cfg                 ),
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -91,6 +92,8 @@ module pcileech_pcie_a7(
         .tlps_out                   ( tlps_rx.source_lite       )
     );
     
+    wire intr_req;
+
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),
         .clk_pcie                   ( clk_pcie                  ),
@@ -101,10 +104,7 @@ module pcileech_pcie_a7(
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
         .pcie_id                    ( pcie_id                   ),   // <- [15:0]
-        // HDA MSI interrupt
-        .cfg_interrupt              ( ctx.cfg_interrupt         ),
-        .cfg_interrupt_assert       ( ctx.cfg_interrupt_assert  ),
-        .cfg_interrupt_di           ( ctx.cfg_interrupt_di      )
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_a7.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;            // interrupt request pulse from TLP to CFG
     
     // system interface
     wire pcie_clk_c;
@@ -91,8 +92,6 @@ module pcileech_pcie_a7(
         .tlp_rx                     ( tlp_rx.sink               ),
         .tlps_out                   ( tlps_rx.source_lite       )
     );
-    
-    wire intr_req;
 
     pcileech_pcie_tlp_a7 i_pcileech_pcie_tlp_a7(
         .rst                        ( rst_subsys                ),

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -38,11 +38,6 @@ module pcileech_pcie_cfg_a7(
     wire            in_empty;
     wire            in_valid;
     
-    reg [63:0]      in_data64;
-    wire [31:0]     in_data32   = in_data64[63:32];
-    wire [15:0]     in_data16   = in_data64[31:16];
-    wire [3:0]      in_type     = in_data64[15:12];
-	
     fifo_64_64 i_fifo_pcie_cfg_tx(
         .rst            ( rst                   ),
         .wr_clk         ( clk_sys               ),

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -280,7 +281,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt                = rw[206] | intr_req;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -290,7 +290,7 @@ module pcileech_pcie_cfg_a7(
         end
     end
 
-    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
+    assign ctx.cfg_interrupt_di             = ctx.cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
     assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -91,6 +91,10 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+
+    // interrupt request latch: hold intr_req pulse until cfg_interrupt_rdy
+    // is asserted, preventing interrupt loss when PCIe core is busy.
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -273,10 +277,23 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    // Latch intr_req pulse and hold until cfg_interrupt_rdy asserts.
+    // Xilinx PCIe core expects cfg_interrupt to remain asserted until rdy.
+    // Without this, a 1-cycle intr_req pulse during rdy=0 is lost forever.
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;  // core accepted, clear latch
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;  // new request, set latch
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206] | intr_req;
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -314,7 +314,7 @@ module pcileech_pcie_cfg_a7(
     // STATE MACHINE / LOGIC FOR READ/WRITE AND OTHER HOUSEKEEPING TASKS
     // ------------------------------------------------------------------------
     
-    integer i_write, i_tlpstatic;
+    integer i_write;
     wire [15:0] in_cmd_address_byte = in_dout[31:16];
     wire [17:0] in_cmd_address_bit  = {in_cmd_address_byte[14:0], 3'b000};
     wire [15:0] in_cmd_value        = {in_dout[48+:8], in_dout[56+:8]};

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -273,7 +273,7 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
-    assign ctx.cfg_interrupt_di             = rw[199:192];
+    assign ctx.cfg_interrupt_di             = cfg_interrupt_do;  // use host-programmed MSI data
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
     assign ctx.cfg_interrupt_assert         = rw[205];
     assign ctx.cfg_interrupt                = rw[206] | intr_req;

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_tlp_a7.sv
@@ -21,24 +21,31 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
     );
-    
+
     IfAXIS128 tlps_bar_rsp();
     IfAXIS128 tlps_cfg_rsp();
-    
+
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards:
     // ------------------------------------------------------------------------
     IfAXIS128 tlps_filtered();
-    
+
     pcileech_tlps128_bar_controller i_pcileech_tlps128_bar_controller(
-        .rst            ( rst                           ),
-        .clk            ( clk_pcie                      ),
-        .bar_en         ( dshadow2fifo.bar_en           ),
-        .pcie_id        ( pcie_id                       ),
-        .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .rst                ( rst                           ),
+        .clk                ( clk_pcie                      ),
+        .bar_en             ( dshadow2fifo.bar_en           ),
+        .pcie_id            ( pcie_id                       ),
+        .tlps_in            ( tlps_rx                       ),
+        .tlps_out           ( tlps_bar_rsp.source           ),
+        .cfg_interrupt      ( cfg_interrupt                 ),
+        .cfg_interrupt_assert( cfg_interrupt_assert         ),
+        .cfg_interrupt_di   ( cfg_interrupt_di              )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_tlp_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_tlp_a7.sv
@@ -22,10 +22,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
     input [15:0]            pcie_id,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
     );
 
     IfAXIS128 tlps_bar_rsp();
@@ -43,9 +41,7 @@ module pcileech_pcie_tlp_a7(
         .pcie_id            ( pcie_id                       ),
         .tlps_in            ( tlps_rx                       ),
         .tlps_out           ( tlps_bar_rsp.source           ),
-        .cfg_interrupt      ( cfg_interrupt                 ),
-        .cfg_interrupt_assert( cfg_interrupt_assert         ),
-        .cfg_interrupt_di   ( cfg_interrupt_di              )
+        .intr_req           ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -595,7 +595,7 @@ module pcileech_tlps128_bar_rdengine(
     wire [11:0] rd_rsp_bc       = rd_rsp_ctx[85:74];
     wire [15:0] rd_rsp_reqid    = rd_rsp_ctx[47:32];
     wire [7:0]  rd_rsp_tag      = rd_rsp_ctx[55:48];
-    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_ctx[6:0];
+    wire [6:0]  rd_rsp_lowaddr  = rd_rsp_first ? rd_rsp_ctx[6:0] : 7'b0;
     wire [31:0] rd_rsp_addr     = rd_rsp_ctx[31:0];
     wire [31:0] rd_rsp_data_bs  = { rd_rsp_data[7:0], rd_rsp_data[15:8], rd_rsp_data[23:16], rd_rsp_data[31:24] };
     

--- a/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -45,9 +45,18 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    // HDA MSI interrupt
+    output                  cfg_interrupt,
+    output                  cfg_interrupt_assert,
+    output [7:0]            cfg_interrupt_di
 );
-    
+
+    // HDA MSI interrupt defaults (idle)
+    assign cfg_interrupt        = 1'b0;
+    assign cfg_interrupt_assert = 1'b0;
+    assign cfg_interrupt_di     = 8'h0;
+
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
     // Receive incoming BAR requests from the TLP stream:

--- a/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -46,16 +46,12 @@ module pcileech_tlps128_bar_controller(
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
     IfAXIS128.source        tlps_out,
-    // HDA MSI interrupt
-    output                  cfg_interrupt,
-    output                  cfg_interrupt_assert,
-    output [7:0]            cfg_interrupt_di
+    // HDA MSI interrupt request
+    output                  intr_req
 );
 
-    // HDA MSI interrupt defaults (idle)
-    assign cfg_interrupt        = 1'b0;
-    assign cfg_interrupt_assert = 1'b0;
-    assign cfg_interrupt_di     = 8'h0;
+    // HDA MSI interrupt request defaults (idle)
+    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:

--- a/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -50,8 +50,6 @@ module pcileech_tlps128_bar_controller(
     output                  intr_req
 );
 
-    // HDA MSI interrupt request defaults (idle)
-    assign intr_req         = 1'b0;
 
     // ------------------------------------------------------------------------
     // 1: TLP RECEIVE:
@@ -85,6 +83,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -151,7 +152,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -166,10 +168,11 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    pcileech_bar_impl_msi i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -181,7 +184,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -196,7 +200,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -211,7 +216,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -226,7 +232,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -241,7 +248,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -695,8 +703,11 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
@@ -727,8 +738,11 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]      rd_req_ctx_1;
     bit [31:0]      rd_req_addr_1;
@@ -766,8 +780,11 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
+
+    assign intr_req = 1'b0;
 
     bit [87:0]  drd_req_ctx;
     bit         drd_req_valid;
@@ -794,5 +811,70 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+endmodule
+
+
+// ------------------------------------------------------------------------
+// BAR implementation: MSI doorbell interrupt generator.
+// Write to offset 0x00 to trigger an MSI interrupt (the written value is
+// the MSI vector/data). Read offset 0x00 to read back the last written
+// value. This allows software to configure and verify the interrupt path.
+// Latency = 2CLKs (matches loopaddr/zerowrite4k for pipeline consistency).
+// ------------------------------------------------------------------------
+module pcileech_bar_impl_msi(
+    input               rst,
+    input               clk,
+    // incoming BAR writes:
+    input [31:0]        wr_addr,
+    input [3:0]         wr_be,
+    input [31:0]        wr_data,
+    input               wr_valid,
+    // incoming BAR reads:
+    input  [87:0]       rd_req_ctx,
+    input  [31:0]       rd_req_addr,
+    input               rd_req_valid,
+    // outgoing BAR read replies:
+    output bit [87:0]   rd_rsp_ctx,
+    output bit [31:0]   rd_rsp_data,
+    output bit          rd_rsp_valid,
+    // MSI interrupt request
+    output              intr_req
+);
+
+    bit [31:0]      doorbell;
+    bit             intr_req_reg;
+    bit [31:0]      doorbell_q;
+    bit             rd_req_valid_q;
+
+    // 2-cycle latency for reads (matches other BAR impls)
+    always @ ( posedge clk ) begin
+        doorbell_q          <= doorbell;
+        rd_req_valid_q      <= rd_req_valid;
+        rd_rsp_ctx          <= rd_req_ctx;
+        rd_rsp_data         <= doorbell_q;
+        rd_rsp_valid        <= rd_req_valid_q;
+    end
+
+    // Doorbell register: write updates value and triggers interrupt pulse
+    always @ ( posedge clk ) begin
+        if ( rst ) begin
+            doorbell    <= 32'h0;
+            intr_req_reg <= 1'b0;
+        end
+        else if ( wr_valid ) begin
+            // Apply byte enables
+            if ( wr_be[0] ) doorbell[7:0]   <= wr_data[7:0];
+            if ( wr_be[1] ) doorbell[15:8]  <= wr_data[15:8];
+            if ( wr_be[2] ) doorbell[23:16] <= wr_data[23:16];
+            if ( wr_be[3] ) doorbell[31:24] <= wr_data[31:24];
+            intr_req_reg <= 1'b1;
+        end
+        else begin
+            intr_req_reg <= 1'b0;
+        end
+    end
+
+    assign intr_req = intr_req_reg;
 
 endmodule

--- a/EnigmaX1/src/pcileech_pcie_a7.sv
+++ b/EnigmaX1/src/pcileech_pcie_a7.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -77,7 +78,8 @@ module pcileech_pcie_a7(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -100,7 +102,8 @@ module pcileech_pcie_a7(
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/EnigmaX1/src/pcileech_pcie_cfg_a7.sv
+++ b/EnigmaX1/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -95,6 +96,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -277,10 +279,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/EnigmaX1/src/pcileech_pcie_tlp_a7.sv
+++ b/EnigmaX1/src/pcileech_pcie_tlp_a7.sv
@@ -21,7 +21,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    output                  intr_req
     );
     
     IfAXIS128 tlps_bar_rsp();
@@ -38,7 +39,8 @@ module pcileech_pcie_tlp_a7(
         .bar_en         ( dshadow2fifo.bar_en           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .tlps_out       ( tlps_bar_rsp.source           ),
+        .intr_req       ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/EnigmaX1/src/pcileech_tlps128_bar_controller.sv
+++ b/EnigmaX1/src/pcileech_tlps128_bar_controller.sv
@@ -45,7 +45,8 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    output                  intr_req
 );
     
     // ------------------------------------------------------------------------
@@ -80,6 +81,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -146,7 +150,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -161,7 +166,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
     pcileech_bar_impl_none i_bar2(
@@ -176,7 +182,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -191,7 +198,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -206,7 +214,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -221,7 +230,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -236,7 +246,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -690,12 +701,14 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
     initial rd_rsp_valid = 0;
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -722,7 +735,8 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]      rd_req_ctx_1;
@@ -737,6 +751,8 @@ module pcileech_bar_impl_loopaddr(
         rd_rsp_data     <= rd_req_addr_1;
         rd_rsp_valid    <= rd_req_valid_1;
     end    
+
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -761,7 +777,8 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]  drd_req_ctx;
@@ -789,5 +806,7 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+    assign intr_req = 1'b0;
 
 endmodule

--- a/GBOX/src/pcileech_pcie_a7x4.sv
+++ b/GBOX/src/pcileech_pcie_a7x4.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7x4(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -77,7 +78,8 @@ module pcileech_pcie_a7x4(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -100,7 +102,8 @@ module pcileech_pcie_a7x4(
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst128 i_pcileech_tlps128_dst128(

--- a/GBOX/src/pcileech_pcie_cfg_a7.sv
+++ b/GBOX/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -95,6 +96,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -277,10 +279,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/GBOX/src/pcileech_pcie_tlp_a7.sv
+++ b/GBOX/src/pcileech_pcie_tlp_a7.sv
@@ -21,7 +21,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    output                  intr_req
     );
     
     IfAXIS128 tlps_bar_rsp();
@@ -38,7 +39,8 @@ module pcileech_pcie_tlp_a7(
         .bar_en         ( dshadow2fifo.bar_en           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .tlps_out       ( tlps_bar_rsp.source           ),
+        .intr_req       ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/GBOX/src/pcileech_tlps128_bar_controller.sv
+++ b/GBOX/src/pcileech_tlps128_bar_controller.sv
@@ -45,7 +45,8 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    output                  intr_req
 );
     
     // ------------------------------------------------------------------------
@@ -80,6 +81,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -146,7 +150,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -161,7 +166,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
     pcileech_bar_impl_none i_bar2(
@@ -176,7 +182,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -191,7 +198,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -206,7 +214,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -221,7 +230,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -236,7 +246,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -690,12 +701,14 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
     initial rd_rsp_valid = 0;
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -722,7 +735,8 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]      rd_req_ctx_1;
@@ -737,6 +751,8 @@ module pcileech_bar_impl_loopaddr(
         rd_rsp_data     <= rd_req_addr_1;
         rd_rsp_valid    <= rd_req_valid_1;
     end    
+
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -761,7 +777,8 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]  drd_req_ctx;
@@ -789,5 +806,7 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+    assign intr_req = 1'b0;
 
 endmodule

--- a/NeTV2/src/pcileech_pcie_a7.sv
+++ b/NeTV2/src/pcileech_pcie_a7.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7(
     IfTlp64         tlp_static();       // static tlp transmit from cfg->tlp
     IfShadow2Tlp    dshadow2tlp();
     wire            user_lnk_up;
+    wire            intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -77,7 +78,8 @@ module pcileech_pcie_a7(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .cfg_tlpcfg                 ( cfg_tlpcfg                ),
-        .tlp_static                 ( tlp_static                )
+        .tlp_static                 ( tlp_static                ),
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -94,7 +96,8 @@ module pcileech_pcie_a7(
         .cfg_tlpcfg                 ( cfg_tlpcfg                ),
         .tlp_static                 ( tlp_static                ),
         .dshadow2fifo               ( dshadow2fifo_tlp          ),
-        .dshadow2tlp                ( dshadow2tlp.tlp           )
+        .dshadow2tlp                ( dshadow2tlp.tlp           ),
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------

--- a/NeTV2/src/pcileech_pcie_cfg_a7.sv
+++ b/NeTV2/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfCfg_TlpCfg.cfg        cfg_tlpcfg,
-    IfTlp64.source          tlp_static
+    IfTlp64.source          tlp_static,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -94,6 +95,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_valid;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -277,10 +279,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/NeTV2/src/pcileech_pcie_tlp_a7.sv
+++ b/NeTV2/src/pcileech_pcie_tlp_a7.sv
@@ -23,8 +23,11 @@ module pcileech_pcie_tlp_a7(
     IfCfg_TlpCfg.tlp        cfg_tlpcfg,
     IfTlp64.sink            tlp_static,
     IfShadow2Fifo.tlp       dshadow2fifo,
-    IfShadow2Tlp.tlp        dshadow2tlp
+    IfShadow2Tlp.tlp        dshadow2tlp,
+    output                  intr_req
     );
+    
+    assign intr_req = 1'b0;
     
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards to FT601

--- a/PCIeSquirrel/src/pcileech_pcie_a7.sv
+++ b/PCIeSquirrel/src/pcileech_pcie_a7.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -77,7 +78,8 @@ module pcileech_pcie_a7(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -100,7 +102,8 @@ module pcileech_pcie_a7(
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/PCIeSquirrel/src/pcileech_pcie_cfg_a7.sv
+++ b/PCIeSquirrel/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -95,6 +96,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -277,10 +279,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/PCIeSquirrel/src/pcileech_pcie_tlp_a7.sv
+++ b/PCIeSquirrel/src/pcileech_pcie_tlp_a7.sv
@@ -21,7 +21,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    output                  intr_req
     );
     
     IfAXIS128 tlps_bar_rsp();
@@ -38,7 +39,8 @@ module pcileech_pcie_tlp_a7(
         .bar_en         ( dshadow2fifo.bar_en           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .tlps_out       ( tlps_bar_rsp.source           ),
+        .intr_req       ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/PCIeSquirrel/src/pcileech_tlps128_bar_controller.sv
+++ b/PCIeSquirrel/src/pcileech_tlps128_bar_controller.sv
@@ -45,7 +45,8 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    output                  intr_req
 );
     
     // ------------------------------------------------------------------------
@@ -80,6 +81,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -146,7 +150,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -161,7 +166,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
     pcileech_bar_impl_none i_bar2(
@@ -176,7 +182,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -191,7 +198,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -206,7 +214,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -221,7 +230,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -236,7 +246,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -690,12 +701,14 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
     initial rd_rsp_valid = 0;
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -722,7 +735,8 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]      rd_req_ctx_1;
@@ -737,6 +751,8 @@ module pcileech_bar_impl_loopaddr(
         rd_rsp_data     <= rd_req_addr_1;
         rd_rsp_valid    <= rd_req_valid_1;
     end    
+
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -761,7 +777,8 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]  drd_req_ctx;
@@ -789,5 +806,7 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+    assign intr_req = 1'b0;
 
 endmodule

--- a/ScreamerM2/src/pcileech_pcie_a7.sv
+++ b/ScreamerM2/src/pcileech_pcie_a7.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -77,7 +78,8 @@ module pcileech_pcie_a7(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -100,7 +102,8 @@ module pcileech_pcie_a7(
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst64 i_pcileech_tlps128_dst64(

--- a/ScreamerM2/src/pcileech_pcie_cfg_a7.sv
+++ b/ScreamerM2/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -95,6 +96,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -277,10 +279,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/ScreamerM2/src/pcileech_pcie_tlp_a7.sv
+++ b/ScreamerM2/src/pcileech_pcie_tlp_a7.sv
@@ -21,7 +21,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    output                  intr_req
     );
     
     IfAXIS128 tlps_bar_rsp();
@@ -38,7 +39,8 @@ module pcileech_pcie_tlp_a7(
         .bar_en         ( dshadow2fifo.bar_en           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .tlps_out       ( tlps_bar_rsp.source           ),
+        .intr_req       ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/ScreamerM2/src/pcileech_tlps128_bar_controller.sv
+++ b/ScreamerM2/src/pcileech_tlps128_bar_controller.sv
@@ -45,7 +45,8 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    output                  intr_req
 );
     
     // ------------------------------------------------------------------------
@@ -80,6 +81,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -146,7 +150,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -161,7 +166,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
     pcileech_bar_impl_none i_bar2(
@@ -176,7 +182,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -191,7 +198,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -206,7 +214,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -221,7 +230,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -236,7 +246,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -690,12 +701,14 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
     initial rd_rsp_valid = 0;
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -722,7 +735,8 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]      rd_req_ctx_1;
@@ -737,6 +751,8 @@ module pcileech_bar_impl_loopaddr(
         rd_rsp_data     <= rd_req_addr_1;
         rd_rsp_valid    <= rd_req_valid_1;
     end    
+
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -761,7 +777,8 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]  drd_req_ctx;
@@ -789,5 +806,7 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+    assign intr_req = 1'b0;
 
 endmodule

--- a/ZDMA/100T/src/pcileech_pcie_a7x4.sv
+++ b/ZDMA/100T/src/pcileech_pcie_a7x4.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7x4(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -77,7 +78,8 @@ module pcileech_pcie_a7x4(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -100,7 +102,8 @@ module pcileech_pcie_a7x4(
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst128 i_pcileech_tlps128_dst128(

--- a/ZDMA/100T/src/pcileech_pcie_cfg_a7.sv
+++ b/ZDMA/100T/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -95,6 +96,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -277,10 +279,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/ZDMA/100T/src/pcileech_pcie_tlp_a7.sv
+++ b/ZDMA/100T/src/pcileech_pcie_tlp_a7.sv
@@ -21,7 +21,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    output                  intr_req
     );
     
     IfAXIS128 tlps_bar_rsp();
@@ -38,7 +39,8 @@ module pcileech_pcie_tlp_a7(
         .bar_en         ( dshadow2fifo.bar_en           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .tlps_out       ( tlps_bar_rsp.source           ),
+        .intr_req       ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/ZDMA/100T/src/pcileech_tlps128_bar_controller.sv
+++ b/ZDMA/100T/src/pcileech_tlps128_bar_controller.sv
@@ -45,7 +45,8 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    output                  intr_req
 );
     
     // ------------------------------------------------------------------------
@@ -80,6 +81,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -146,7 +150,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -161,7 +166,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
     pcileech_bar_impl_none i_bar2(
@@ -176,7 +182,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -191,7 +198,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -206,7 +214,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -221,7 +230,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -236,7 +246,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -690,12 +701,14 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
     initial rd_rsp_valid = 0;
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -722,7 +735,8 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]      rd_req_ctx_1;
@@ -737,6 +751,8 @@ module pcileech_bar_impl_loopaddr(
         rd_rsp_data     <= rd_req_addr_1;
         rd_rsp_valid    <= rd_req_valid_1;
     end    
+
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -761,7 +777,8 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]  drd_req_ctx;
@@ -789,5 +806,7 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+    assign intr_req = 1'b0;
 
 endmodule

--- a/ac701_ft601/src/pcileech_pcie_a7x4.sv
+++ b/ac701_ft601/src/pcileech_pcie_a7x4.sv
@@ -46,6 +46,7 @@ module pcileech_pcie_a7x4(
     IfAXIS128               tlps_static();       // static tlp transmit from cfg->tlp
     wire [15:0]             pcie_id;
     wire                    user_lnk_up;
+    wire                    intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -77,7 +78,8 @@ module pcileech_pcie_a7x4(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .tlps_static                ( tlps_static.source        ),
-        .pcie_id                    ( pcie_id                   )   // -> [15:0]
+        .pcie_id                    ( pcie_id                   ),   // -> [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -100,7 +102,8 @@ module pcileech_pcie_a7x4(
         .tlps_rx                    ( tlps_rx.sink_lite         ),
         .tlps_static                ( tlps_static.sink          ),
         .dshadow2fifo               ( dshadow2fifo              ),
-        .pcie_id                    ( pcie_id                   )   // <- [15:0]
+        .pcie_id                    ( pcie_id                   ),   // <- [15:0]
+        .intr_req                   ( intr_req                  )
     );
     
     pcileech_tlps128_dst128 i_pcileech_tlps128_dst128(

--- a/ac701_ft601/src/pcileech_pcie_cfg_a7.sv
+++ b/ac701_ft601/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfAXIS128.source        tlps_static,
-    output [15:0]           pcie_id
+    output [15:0]           pcie_id,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -95,6 +96,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_2nd;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -277,10 +279,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/ac701_ft601/src/pcileech_pcie_tlp_a7.sv
+++ b/ac701_ft601/src/pcileech_pcie_tlp_a7.sv
@@ -21,7 +21,8 @@ module pcileech_pcie_tlp_a7(
     IfAXIS128.sink_lite     tlps_rx,
     IfAXIS128.sink          tlps_static,
     IfShadow2Fifo.shadow    dshadow2fifo,
-    input [15:0]            pcie_id
+    input [15:0]            pcie_id,
+    output                  intr_req
     );
     
     IfAXIS128 tlps_bar_rsp();
@@ -38,7 +39,8 @@ module pcileech_pcie_tlp_a7(
         .bar_en         ( dshadow2fifo.bar_en           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_rx                       ),
-        .tlps_out       ( tlps_bar_rsp.source           )
+        .tlps_out       ( tlps_bar_rsp.source           ),
+        .intr_req       ( intr_req                      )
     );
     
     pcileech_tlps128_cfgspace_shadow i_pcileech_tlps128_cfgspace_shadow(

--- a/ac701_ft601/src/pcileech_tlps128_bar_controller.sv
+++ b/ac701_ft601/src/pcileech_tlps128_bar_controller.sv
@@ -45,7 +45,8 @@ module pcileech_tlps128_bar_controller(
     input                   bar_en,
     input [15:0]            pcie_id,
     IfAXIS128.sink_lite     tlps_in,
-    IfAXIS128.source        tlps_out
+    IfAXIS128.source        tlps_out,
+    output                  intr_req
 );
     
     // ------------------------------------------------------------------------
@@ -80,6 +81,9 @@ module pcileech_tlps128_bar_controller(
     wire [87:0] rd_rsp_ctx;
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
+
+    wire [6:0]  bar_intr_req;
+    assign intr_req = |bar_intr_req;
         
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
         .rst            ( rst                           ),
@@ -146,7 +150,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
         .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_valid   ( bar_rsp_valid[0]              ),
+        .intr_req       ( bar_intr_req[0]               )
     );
     
     pcileech_bar_impl_loopaddr i_bar1(
@@ -161,7 +166,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
         .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_rsp_valid   ( bar_rsp_valid[1]              ),
+        .intr_req       ( bar_intr_req[1]               )
     );
     
     pcileech_bar_impl_none i_bar2(
@@ -176,7 +182,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
         .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
+        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
+        .intr_req       ( bar_intr_req[2]               )
     );
     
     pcileech_bar_impl_none i_bar3(
@@ -191,7 +198,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
         .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
+        .rd_rsp_valid   ( bar_rsp_valid[3]              ),
+        .intr_req       ( bar_intr_req[3]               )
     );
     
     pcileech_bar_impl_none i_bar4(
@@ -206,7 +214,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
         .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
+        .rd_rsp_valid   ( bar_rsp_valid[4]              ),
+        .intr_req       ( bar_intr_req[4]               )
     );
     
     pcileech_bar_impl_none i_bar5(
@@ -221,7 +230,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
         .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
+        .rd_rsp_valid   ( bar_rsp_valid[5]              ),
+        .intr_req       ( bar_intr_req[5]               )
     );
     
     pcileech_bar_impl_none i_bar6_optrom(
@@ -236,7 +246,8 @@ module pcileech_tlps128_bar_controller(
         .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
         .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
         .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
+        .rd_rsp_valid   ( bar_rsp_valid[6]              ),
+        .intr_req       ( bar_intr_req[6]               )
     );
 
 
@@ -690,12 +701,14 @@ module pcileech_bar_impl_none(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     initial rd_rsp_ctx = 0;
     initial rd_rsp_data = 0;
     initial rd_rsp_valid = 0;
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -722,7 +735,8 @@ module pcileech_bar_impl_loopaddr(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]      rd_req_ctx_1;
@@ -737,6 +751,8 @@ module pcileech_bar_impl_loopaddr(
         rd_rsp_data     <= rd_req_addr_1;
         rd_rsp_valid    <= rd_req_valid_1;
     end    
+
+    assign intr_req = 1'b0;
 
 endmodule
 
@@ -761,7 +777,8 @@ module pcileech_bar_impl_zerowrite4k(
     // outgoing BAR read replies:
     output bit [87:0]   rd_rsp_ctx,
     output bit [31:0]   rd_rsp_data,
-    output bit          rd_rsp_valid
+    output bit          rd_rsp_valid,
+    output              intr_req
 );
 
     bit [87:0]  drd_req_ctx;
@@ -789,5 +806,7 @@ module pcileech_bar_impl_zerowrite4k(
         .doutb  ( doutb             ),
         .enb    ( rd_req_valid      )
     );
+
+    assign intr_req = 1'b0;
 
 endmodule

--- a/acorn_ft2232h/src/pcileech_pcie_a7.sv
+++ b/acorn_ft2232h/src/pcileech_pcie_a7.sv
@@ -45,6 +45,7 @@ module pcileech_pcie_a7(
     IfTlp64         tlp_static();       // static tlp transmit from cfg->tlp
     IfShadow2Tlp    dshadow2tlp();
     wire            user_lnk_up;
+    wire            intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -76,7 +77,8 @@ module pcileech_pcie_a7(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .cfg_tlpcfg                 ( cfg_tlpcfg                ),
-        .tlp_static                 ( tlp_static                )
+        .tlp_static                 ( tlp_static                ),
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -93,7 +95,8 @@ module pcileech_pcie_a7(
         .cfg_tlpcfg                 ( cfg_tlpcfg                ),
         .tlp_static                 ( tlp_static                ),
         .dshadow2fifo               ( dshadow2fifo_tlp          ),
-        .dshadow2tlp                ( dshadow2tlp.tlp           )
+        .dshadow2tlp                ( dshadow2tlp.tlp           ),
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------

--- a/acorn_ft2232h/src/pcileech_pcie_cfg_a7.sv
+++ b/acorn_ft2232h/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfCfg_TlpCfg.cfg        cfg_tlpcfg,
-    IfTlp64.source          tlp_static
+    IfTlp64.source          tlp_static,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -94,6 +95,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_valid;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -276,10 +278,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/acorn_ft2232h/src/pcileech_pcie_tlp_a7.sv
+++ b/acorn_ft2232h/src/pcileech_pcie_tlp_a7.sv
@@ -23,8 +23,11 @@ module pcileech_pcie_tlp_a7(
     IfCfg_TlpCfg.tlp        cfg_tlpcfg,
     IfTlp64.sink            tlp_static,
     IfShadow2Fifo.tlp       dshadow2fifo,
-    IfShadow2Tlp.tlp        dshadow2tlp
+    IfShadow2Tlp.tlp        dshadow2tlp,
+    output                  intr_req
     );
+    
+    assign intr_req = 1'b0;
     
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards to FT601

--- a/pciescreamer/src/pcileech_pcie_a7.sv
+++ b/pciescreamer/src/pcileech_pcie_a7.sv
@@ -45,6 +45,7 @@ module pcileech_pcie_a7(
     IfTlp64         tlp_static();       // static tlp transmit from cfg->tlp
     IfShadow2Tlp    dshadow2tlp();
     wire            user_lnk_up;
+    wire            intr_req;
     
     // system interface
     wire pcie_clk_c;
@@ -76,7 +77,8 @@ module pcileech_pcie_a7(
         .dfifo                      ( dfifo_cfg                 ),        
         .ctx                        ( ctx                       ),
         .cfg_tlpcfg                 ( cfg_tlpcfg                ),
-        .tlp_static                 ( tlp_static                )
+        .tlp_static                 ( tlp_static                ),
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------
@@ -93,7 +95,8 @@ module pcileech_pcie_a7(
         .cfg_tlpcfg                 ( cfg_tlpcfg                ),
         .tlp_static                 ( tlp_static                ),
         .dshadow2fifo               ( dshadow2fifo_tlp          ),
-        .dshadow2tlp                ( dshadow2tlp.tlp           )
+        .dshadow2tlp                ( dshadow2tlp.tlp           ),
+        .intr_req                   ( intr_req                  )
     );
     
     // ----------------------------------------------------------------------------

--- a/pciescreamer/src/pcileech_pcie_cfg_a7.sv
+++ b/pciescreamer/src/pcileech_pcie_cfg_a7.sv
@@ -17,7 +17,8 @@ module pcileech_pcie_cfg_a7(
     IfPCIeFifoCfg.mp_pcie   dfifo,
     IfPCIeSignals.mpm       ctx,
     IfCfg_TlpCfg.cfg        cfg_tlpcfg,
-    IfTlp64.source          tlp_static
+    IfTlp64.source          tlp_static,
+    input                   intr_req
     );
 
     // ----------------------------------------------------
@@ -94,6 +95,7 @@ module pcileech_pcie_cfg_a7(
     reg                 rwi_tlp_static_valid;
     reg                 rwi_tlp_static_has_data;
     reg     [31:0]      rwi_count_cfgspace_status_cl;
+    reg                 intr_req_pending;
    
     // ------------------------------------------------------------------------
     // REGISTER FILE: READ-ONLY LAYOUT/SPECIFICATION
@@ -276,10 +278,20 @@ module pcileech_pcie_cfg_a7(
     assign ctx.pl_transmit_hot_rst          = rw[183];
     assign ctx.pl_downstream_deemph_source  = rw[184];
     
+    always @(posedge clk_pcie) begin
+        if (rst) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin
+            intr_req_pending <= 1'b0;
+        end else if (intr_req) begin
+            intr_req_pending <= 1'b1;
+        end
+    end
+
     assign ctx.cfg_interrupt_di             = rw[199:192];
     assign ctx.cfg_pciecap_interrupt_msgnum = rw[204:200];
-    assign ctx.cfg_interrupt_assert         = rw[205];
-    assign ctx.cfg_interrupt                = rw[206];
+    assign ctx.cfg_interrupt_assert         = rw[205] | intr_req_pending;
+    assign ctx.cfg_interrupt                = rw[206] | intr_req_pending;
     assign ctx.cfg_interrupt_stat           = rw[207];
 
     assign ctx.cfg_pm_force_state           = rw[209:208];

--- a/pciescreamer/src/pcileech_pcie_tlp_a7.sv
+++ b/pciescreamer/src/pcileech_pcie_tlp_a7.sv
@@ -23,8 +23,11 @@ module pcileech_pcie_tlp_a7(
     IfCfg_TlpCfg.tlp        cfg_tlpcfg,
     IfTlp64.sink            tlp_static,
     IfShadow2Fifo.tlp       dshadow2fifo,
-    IfShadow2Tlp.tlp        dshadow2tlp
+    IfShadow2Tlp.tlp        dshadow2tlp,
+    output                  intr_req
     );
+    
+    assign intr_req = 1'b0;
     
     // ------------------------------------------------------------------------
     // Convert received TLPs from PCIe core and transmit onwards to FT601


### PR DESCRIPTION
## summary
- fix split completion lower address in bar read engine - only the first completion carries the original lower address per pcie spec, subsequent ones should be zeroed
- fix x1 tlp sink reset signal - switched dst64 module from global rst to rst_subsys so it resets properly during link training/recovery
- bump firmware version to 4.18

this code is licensed under the mit license.