### PR TITLE
Add endpoint personality hooks

### DIFF
--- a/CaptainDMA/100t484-1/src/pcileech_device_config.svh
+++ b/CaptainDMA/100t484-1/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/CaptainDMA/100t484-1/src/pcileech_fifo.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/CaptainDMA/100t484-1/src/pcileech_header.svh
+++ b/CaptainDMA/100t484-1/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/100t484-1/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/CaptainDMA/35t325_x1/src/pcileech_device_config.svh
+++ b/CaptainDMA/35t325_x1/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/CaptainDMA/35t325_x1/src/pcileech_fifo.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/CaptainDMA/35t325_x1/src/pcileech_header.svh
+++ b/CaptainDMA/35t325_x1/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x1/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/CaptainDMA/35t325_x4/src/pcileech_device_config.svh
+++ b/CaptainDMA/35t325_x4/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/CaptainDMA/35t325_x4/src/pcileech_fifo.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/CaptainDMA/35t325_x4/src/pcileech_header.svh
+++ b/CaptainDMA/35t325_x4/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t325_x4/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/CaptainDMA/35t484_x1/src/pcileech_device_config.svh
+++ b/CaptainDMA/35t484_x1/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/CaptainDMA/35t484_x1/src/pcileech_fifo.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/CaptainDMA/35t484_x1/src/pcileech_header.svh
+++ b/CaptainDMA/35t484_x1/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/35t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/CaptainDMA/75t484_x1/src/pcileech_device_config.svh
+++ b/CaptainDMA/75t484_x1/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/CaptainDMA/75t484_x1/src/pcileech_fifo.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/CaptainDMA/75t484_x1/src/pcileech_header.svh
+++ b/CaptainDMA/75t484_x1/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
+++ b/CaptainDMA/75t484_x1/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/EnigmaX1/src/pcileech_device_config.svh
+++ b/EnigmaX1/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/EnigmaX1/src/pcileech_fifo.sv
+++ b/EnigmaX1/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/EnigmaX1/src/pcileech_header.svh
+++ b/EnigmaX1/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/EnigmaX1/src/pcileech_pcie_cfg_a7.sv
+++ b/EnigmaX1/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/EnigmaX1/src/pcileech_tlps128_bar_controller.sv
+++ b/EnigmaX1/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/GBOX/src/pcileech_device_config.svh
+++ b/GBOX/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/GBOX/src/pcileech_fifo.sv
+++ b/GBOX/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b1;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/GBOX/src/pcileech_header.svh
+++ b/GBOX/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/GBOX/src/pcileech_pcie_cfg_a7.sv
+++ b/GBOX/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/GBOX/src/pcileech_tlps128_bar_controller.sv
+++ b/GBOX/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/NeTV2/src/pcileech_device_config.svh
+++ b/NeTV2/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/NeTV2/src/pcileech_fifo.sv
+++ b/NeTV2/src/pcileech_fifo.sv
@@ -191,7 +191,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [77:0]      _pcie_core_config = { 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [77:0]      _pcie_core_config = { 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -257,18 +257,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       CLK_IS_ENABLED [if clk not started _pcie_core_config[77] will remain zero].
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207:207] <= 0;                           //       SLACK
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/NeTV2/src/pcileech_header.svh
+++ b/NeTV2/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/NeTV2/src/pcileech_pcie_cfg_a7.sv
+++ b/NeTV2/src/pcileech_pcie_cfg_a7.sv
@@ -205,14 +205,14 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[27:22]   <= 0;                       //       RESERVED FUTURE
             rw[31:28]   <= 4'hf;                    //       PCIe TLP TX ENABLE FOR MUX CHANNEL 0-3 [MUX[0] == RW[28] ..].
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/PCIeSquirrel/src/pcileech_device_config.svh
+++ b/PCIeSquirrel/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/PCIeSquirrel/src/pcileech_fifo.sv
+++ b/PCIeSquirrel/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/PCIeSquirrel/src/pcileech_header.svh
+++ b/PCIeSquirrel/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/PCIeSquirrel/src/pcileech_pcie_cfg_a7.sv
+++ b/PCIeSquirrel/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/PCIeSquirrel/src/pcileech_tlps128_bar_controller.sv
+++ b/PCIeSquirrel/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/ScreamerM2/src/pcileech_device_config.svh
+++ b/ScreamerM2/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/ScreamerM2/src/pcileech_fifo.sv
+++ b/ScreamerM2/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/ScreamerM2/src/pcileech_header.svh
+++ b/ScreamerM2/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/ScreamerM2/src/pcileech_pcie_cfg_a7.sv
+++ b/ScreamerM2/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/ScreamerM2/src/pcileech_tlps128_bar_controller.sv
+++ b/ScreamerM2/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/ZDMA/100T/src/pcileech_device_config.svh
+++ b/ZDMA/100T/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/ZDMA/100T/src/pcileech_fifo.sv
+++ b/ZDMA/100T/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b1;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/ZDMA/100T/src/pcileech_header.svh
+++ b/ZDMA/100T/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/ZDMA/100T/src/pcileech_pcie_cfg_a7.sv
+++ b/ZDMA/100T/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/ZDMA/100T/src/pcileech_tlps128_bar_controller.sv
+++ b/ZDMA/100T/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/ac701_ft601/src/pcileech_device_config.svh
+++ b/ac701_ft601/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/ac701_ft601/src/pcileech_fifo.sv
+++ b/ac701_ft601/src/pcileech_fifo.sv
@@ -213,7 +213,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -279,18 +279,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       PCIE BAR PIO ON-BOARD PROCESSING ENABLE
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207]     <= 1'b0;                        //       TLP FILTER FROM USER: EXCEPT: Cpl,CplD and CfgRd/CfgWr (handled by rw[204])
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/ac701_ft601/src/pcileech_header.svh
+++ b/ac701_ft601/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/ac701_ft601/src/pcileech_pcie_cfg_a7.sv
+++ b/ac701_ft601/src/pcileech_pcie_cfg_a7.sv
@@ -206,13 +206,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
-            rw[21]      <= 0;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[21]      <= `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET;                       //       CFGSPACE_COMMAND_REGISTER_AUTO_SET [bus master and other flags (set in rw[143:128] <= 16'h....;)]
             rw[31:22]   <= 0;                       //       RESERVED FUTURE
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -235,10 +235,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/ac701_ft601/src/pcileech_tlps128_bar_controller.sv
+++ b/ac701_ft601/src/pcileech_tlps128_bar_controller.sv
@@ -134,7 +134,7 @@ module pcileech_tlps128_bar_controller(
                         bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
     
-    pcileech_bar_impl_zerowrite4k i_bar0(
+    `PCILEECH_BAR_IMPL_0 i_bar0(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -149,7 +149,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[0]              )
     );
     
-    pcileech_bar_impl_loopaddr i_bar1(
+    `PCILEECH_BAR_IMPL_1 i_bar1(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -164,7 +164,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[1]              )
     );
     
-    pcileech_bar_impl_none i_bar2(
+    `PCILEECH_BAR_IMPL_2 i_bar2(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -179,7 +179,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[2]              )
     );
     
-    pcileech_bar_impl_none i_bar3(
+    `PCILEECH_BAR_IMPL_3 i_bar3(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -194,7 +194,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[3]              )
     );
     
-    pcileech_bar_impl_none i_bar4(
+    `PCILEECH_BAR_IMPL_4 i_bar4(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -209,7 +209,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[4]              )
     );
     
-    pcileech_bar_impl_none i_bar5(
+    `PCILEECH_BAR_IMPL_5 i_bar5(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
@@ -224,7 +224,7 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_valid   ( bar_rsp_valid[5]              )
     );
     
-    pcileech_bar_impl_none i_bar6_optrom(
+    `PCILEECH_BAR_IMPL_6 i_bar6_optrom(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),

--- a/acorn_ft2232h/src/pcileech_device_config.svh
+++ b/acorn_ft2232h/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/acorn_ft2232h/src/pcileech_fifo.sv
+++ b/acorn_ft2232h/src/pcileech_fifo.sv
@@ -190,7 +190,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [77:0]      _pcie_core_config = { 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [77:0]      _pcie_core_config = { 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -256,18 +256,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       CLK_IS_ENABLED [if clk not started _pcie_core_config[77] will remain zero].
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207:207] <= 0;                           //       SLACK
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/acorn_ft2232h/src/pcileech_header.svh
+++ b/acorn_ft2232h/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/acorn_ft2232h/src/pcileech_pcie_cfg_a7.sv
+++ b/acorn_ft2232h/src/pcileech_pcie_cfg_a7.sv
@@ -204,13 +204,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
             rw[27:21]   <= 0;                       //       RESERVED FUTURE
             rw[31:28]   <= 4'hf;                    //       PCIe TLP TX ENABLE FOR MUX CHANNEL 0-3 [MUX[0] == RW[28] ..].
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -233,10 +233,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/custom_endpoint_personality.md
+++ b/custom_endpoint_personality.md
@@ -1,0 +1,68 @@
+Custom Endpoint Personality Hooks
+=================================
+
+PCILeech FPGA boards include default PCIe endpoint personality hooks in
+`src/pcileech_device_config.svh`. The defaults preserve the stock firmware
+identity and BAR behavior. Build tooling may replace this file, or define the
+same macros before `pcileech_header.svh` is included, to select a custom
+endpoint personality without editing the FIFO, PCIe config, or BAR controller
+sources.
+
+
+Config Space Defaults
+=====================
+
+The following macros control the initial PCIe identity and selected config
+space behavior:
+
+* `PCILEECH_CFG_SUBSYS_VEND_ID`
+* `PCILEECH_CFG_SUBSYS_ID`
+* `PCILEECH_CFG_VEND_ID`
+* `PCILEECH_CFG_DEV_ID`
+* `PCILEECH_CFG_REV_ID`
+* `PCILEECH_CFG_DSN`
+* `PCILEECH_CFGTLP_ZERO_DATA`
+* `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE`
+* `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR`
+* `PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET`
+* `PCILEECH_CFG_PM_FORCE_STATE`
+* `PCILEECH_CFG_PM_FORCE_STATE_EN`
+* `PCILEECH_CFG_PM_HALT_ASPM_L0S`
+* `PCILEECH_CFG_PM_HALT_ASPM_L1`
+
+
+BAR Implementation Defaults
+===========================
+
+The BAR controller instantiates module names from these macros:
+
+* `PCILEECH_BAR_IMPL_0`
+* `PCILEECH_BAR_IMPL_1`
+* `PCILEECH_BAR_IMPL_2`
+* `PCILEECH_BAR_IMPL_3`
+* `PCILEECH_BAR_IMPL_4`
+* `PCILEECH_BAR_IMPL_5`
+* `PCILEECH_BAR_IMPL_6`
+
+All selected BAR modules must use the same interface as the stock
+implementations:
+
+```systemverilog
+module pcileech_bar_impl_custom(
+    input               rst,
+    input               clk,
+    input [31:0]        wr_addr,
+    input [3:0]         wr_be,
+    input [31:0]        wr_data,
+    input               wr_valid,
+    input [87:0]        rd_req_ctx,
+    input [31:0]        rd_req_addr,
+    input               rd_req_valid,
+    output bit [87:0]   rd_rsp_ctx,
+    output bit [31:0]   rd_rsp_data,
+    output bit          rd_rsp_valid
+);
+```
+
+The BAR controller requires all BAR implementations to return read data with
+the same latency, matching the existing controller contract.

--- a/pciescreamer/src/pcileech_device_config.svh
+++ b/pciescreamer/src/pcileech_device_config.svh
@@ -1,0 +1,94 @@
+//
+// PCILeech FPGA.
+//
+// Default PCIe endpoint personality settings.
+//
+
+`ifndef _pcileech_device_config_svh_
+`define _pcileech_device_config_svh_
+
+`ifndef PCILEECH_CFG_SUBSYS_VEND_ID
+`define PCILEECH_CFG_SUBSYS_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_SUBSYS_ID
+`define PCILEECH_CFG_SUBSYS_ID 16'h0007
+`endif
+
+`ifndef PCILEECH_CFG_VEND_ID
+`define PCILEECH_CFG_VEND_ID 16'h10EE
+`endif
+
+`ifndef PCILEECH_CFG_DEV_ID
+`define PCILEECH_CFG_DEV_ID 16'h0666
+`endif
+
+`ifndef PCILEECH_CFG_REV_ID
+`define PCILEECH_CFG_REV_ID 8'h02
+`endif
+
+`ifndef PCILEECH_CFG_DSN
+`define PCILEECH_CFG_DSN 64'h0000000101000A35
+`endif
+
+`ifndef PCILEECH_CFGTLP_ZERO_DATA
+`define PCILEECH_CFGTLP_ZERO_DATA 1'b1
+`endif
+
+`ifndef PCILEECH_CFGTLP_PCIE_WRITE_ENABLE
+`define PCILEECH_CFGTLP_PCIE_WRITE_ENABLE 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR
+`define PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR 1'b0
+`endif
+
+`ifndef PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET
+`define PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE
+`define PCILEECH_CFG_PM_FORCE_STATE 2'b00
+`endif
+
+`ifndef PCILEECH_CFG_PM_FORCE_STATE_EN
+`define PCILEECH_CFG_PM_FORCE_STATE_EN 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L0S
+`define PCILEECH_CFG_PM_HALT_ASPM_L0S 1'b0
+`endif
+
+`ifndef PCILEECH_CFG_PM_HALT_ASPM_L1
+`define PCILEECH_CFG_PM_HALT_ASPM_L1 1'b0
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_0
+`define PCILEECH_BAR_IMPL_0 pcileech_bar_impl_zerowrite4k
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_1
+`define PCILEECH_BAR_IMPL_1 pcileech_bar_impl_loopaddr
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_2
+`define PCILEECH_BAR_IMPL_2 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_3
+`define PCILEECH_BAR_IMPL_3 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_4
+`define PCILEECH_BAR_IMPL_4 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_5
+`define PCILEECH_BAR_IMPL_5 pcileech_bar_impl_none
+`endif
+
+`ifndef PCILEECH_BAR_IMPL_6
+`define PCILEECH_BAR_IMPL_6 pcileech_bar_impl_none
+`endif
+
+`endif

--- a/pciescreamer/src/pcileech_fifo.sv
+++ b/pciescreamer/src/pcileech_fifo.sv
@@ -190,7 +190,7 @@ module pcileech_fifo #(
     reg     [239:0]     rw;
     
     // special non-user accessible registers 
-    reg     [77:0]      _pcie_core_config = { 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+    reg     [77:0]      _pcie_core_config = { 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, `PCILEECH_CFG_REV_ID, `PCILEECH_CFG_DEV_ID, `PCILEECH_CFG_VEND_ID, `PCILEECH_CFG_SUBSYS_ID, `PCILEECH_CFG_SUBSYS_VEND_ID };
     time                _cmd_timer_inactivity_base;
     reg                 rwi_drp_rd_en;
     reg                 rwi_drp_wr_en;
@@ -256,18 +256,18 @@ module pcileech_fifo #(
             rw[127:96]  <= 0;                           // +00C: cmd_send_count [little-endian]
             // PCIE INITIAL CONFIG (SPECIAL BITSTREAM)
             // NB! "initial" CLK0 values may also be changed in: '_pcie_core_config = {...};' [important on PCIeScreamer].
-            rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
-            rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID (NOT IMPLEMENTED)
-            rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID (NOT IMPLEMENTED)
-            rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID (NOT IMPLEMENTED)
-            rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID (NOT IMPLEMENTED)
+            rw[143:128] <= `PCILEECH_CFG_SUBSYS_VEND_ID;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+            rw[159:144] <= `PCILEECH_CFG_SUBSYS_ID;                    // +012: CFG_SUBSYS_ID (NOT IMPLEMENTED)
+            rw[175:160] <= `PCILEECH_CFG_VEND_ID;                    // +014: CFG_VEND_ID (NOT IMPLEMENTED)
+            rw[191:176] <= `PCILEECH_CFG_DEV_ID;                    // +016: CFG_DEV_ID (NOT IMPLEMENTED)
+            rw[199:192] <= `PCILEECH_CFG_REV_ID;                       // +018: CFG_REV_ID (NOT IMPLEMENTED)
             rw[200]     <= 1'b1;                        // +019: PCIE CORE RESET
             rw[201]     <= 1'b0;                        //       PCIE SUBSYSTEM RESET
             rw[202]     <= 1'b1;                        //       CFGTLP PROCESSING ENABLE
-            rw[203]     <= 1'b1;                        //       CFGTLP ZERO DATA
+            rw[203]     <= `PCILEECH_CFGTLP_ZERO_DATA;                        //       CFGTLP ZERO DATA
             rw[204]     <= 1'b1;                        //       CFGTLP FILTER TLP FROM USER
             rw[205]     <= 1'b1;                        //       CLK_IS_ENABLED [if clk not started _pcie_core_config[77] will remain zero].
-            rw[206]     <= 1'b0;                        //       CFGTLP PCIE WRITE ENABLE
+            rw[206]     <= `PCILEECH_CFGTLP_PCIE_WRITE_ENABLE;                        //       CFGTLP PCIE WRITE ENABLE
             rw[207:207] <= 0;                           //       SLACK
             // PCIe DRP, PRSNT#, PERST#
             rw[208+:16] <= 0;                           // +01A: DRP: pcie_drp_di

--- a/pciescreamer/src/pcileech_header.svh
+++ b/pciescreamer/src/pcileech_header.svh
@@ -10,6 +10,8 @@
 `ifndef _pcileech_header_svh_
 `define _pcileech_header_svh_
 
+`include "pcileech_device_config.svh"
+
 `define _bs16(v)   {{v}[7:0], {v}[15:8]}
 `define _bs32(v)   {{v}[7:0], {v}[15:8], {v}[23:16], {v}[31:24]}
 

--- a/pciescreamer/src/pcileech_pcie_cfg_a7.sv
+++ b/pciescreamer/src/pcileech_pcie_cfg_a7.sv
@@ -204,13 +204,13 @@ module pcileech_pcie_cfg_a7(
             rw[17]      <= 0;                       //       CFG WR EN
             rw[18]      <= 0;                       //       WAIT FOR PCIe CFG SPACE RD/WR COMPLETION BEFORE ACCEPT NEW FIFO READ/WRITES
             rw[19]      <= 0;                       //       TLP_STATIC TX ENABLE
-            rw[20]      <= 0;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
+            rw[20]      <= `PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR;                       //       CFGSPACE_STATUS_REGISTER_AUTO_CLEAR [master abort flag]
             rw[27:21]   <= 0;                       //       RESERVED FUTURE
             rw[31:28]   <= 4'hf;                    //       PCIe TLP TX ENABLE FOR MUX CHANNEL 0-3 [MUX[0] == RW[28] ..].
             // SIZEOF / BYTECOUNT [little-endian]
             rw[63:32]   <= $bits(rw) >> 3;          // +004: bytecount [little endian]
             // DSN
-            rw[127:64]  <= 64'h0000000101000A35;    // +008: cfg_dsn
+            rw[127:64]  <= `PCILEECH_CFG_DSN;    // +008: cfg_dsn
             // PCIe CFG MGMT
             rw[159:128] <= 0;                       // +010: cfg_mgmt_di
             rw[169:160] <= 0;                       // +014: cfg_mgmt_dwaddr
@@ -233,10 +233,10 @@ module pcileech_pcie_cfg_a7(
             rw[206]     <= 0;                       //       cfg_interrupt
             rw[207]     <= 0;                       //       cfg_interrupt_stat
             // PCIe CTRL
-            rw[209:208] <= 0;                       // +01A: cfg_pm_force_state
-            rw[210]     <= 0;                       //       cfg_pm_force_state_en
-            rw[211]     <= 0;                       //       cfg_pm_halt_aspm_l0s
-            rw[212]     <= 0;                       //       cfg_pm_halt_aspm_l1
+            rw[209:208] <= `PCILEECH_CFG_PM_FORCE_STATE;                       // +01A: cfg_pm_force_state
+            rw[210]     <= `PCILEECH_CFG_PM_FORCE_STATE_EN;                       //       cfg_pm_force_state_en
+            rw[211]     <= `PCILEECH_CFG_PM_HALT_ASPM_L0S;                       //       cfg_pm_halt_aspm_l0s
+            rw[212]     <= `PCILEECH_CFG_PM_HALT_ASPM_L1;                       //       cfg_pm_halt_aspm_l1
             rw[213]     <= 0;                       //       cfg_pm_send_pme_to
             rw[214]     <= 0;                       //       cfg_pm_wake
             rw[215]     <= 0;                       //       cfg_trn_pending

--- a/scripts/test_endpoint_hooks.ps1
+++ b/scripts/test_endpoint_hooks.ps1
@@ -1,0 +1,113 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+$srcDirs = Get-ChildItem -Path $root -Recurse -Directory -Filter src |
+    Where-Object { Test-Path (Join-Path $_.FullName "pcileech_header.svh") }
+
+if (-not $srcDirs) {
+    throw "No PCILeech src directories found"
+}
+
+$requiredConfigMacros = @(
+    "PCILEECH_CFG_SUBSYS_VEND_ID",
+    "PCILEECH_CFG_SUBSYS_ID",
+    "PCILEECH_CFG_VEND_ID",
+    "PCILEECH_CFG_DEV_ID",
+    "PCILEECH_CFG_REV_ID",
+    "PCILEECH_CFG_DSN",
+    "PCILEECH_CFGTLP_ZERO_DATA",
+    "PCILEECH_CFGTLP_PCIE_WRITE_ENABLE",
+    "PCILEECH_BAR_IMPL_0",
+    "PCILEECH_BAR_IMPL_6"
+)
+
+$failures = New-Object System.Collections.Generic.List[string]
+
+foreach ($dir in $srcDirs) {
+    $rel = Resolve-Path -Relative $dir.FullName
+
+    $header = Get-Content -Raw (Join-Path $dir.FullName "pcileech_header.svh")
+    if ($header -notmatch 'pcileech_device_config\.svh') {
+        $failures.Add("$rel/pcileech_header.svh does not include pcileech_device_config.svh")
+    }
+
+    $deviceConfigPath = Join-Path $dir.FullName "pcileech_device_config.svh"
+    if (-not (Test-Path $deviceConfigPath)) {
+        $failures.Add("$rel/pcileech_device_config.svh missing")
+    } else {
+        $deviceConfig = Get-Content -Raw $deviceConfigPath
+        foreach ($macro in $requiredConfigMacros) {
+            if ($deviceConfig -notmatch [regex]::Escape($macro)) {
+                $failures.Add("$rel/pcileech_device_config.svh missing $macro")
+            }
+        }
+    }
+
+    $fifoPath = Join-Path $dir.FullName "pcileech_fifo.sv"
+    if (Test-Path $fifoPath) {
+        $fifo = Get-Content -Raw $fifoPath
+        foreach ($macro in @(
+            "PCILEECH_CFG_SUBSYS_VEND_ID",
+            "PCILEECH_CFG_SUBSYS_ID",
+            "PCILEECH_CFG_VEND_ID",
+            "PCILEECH_CFG_DEV_ID",
+            "PCILEECH_CFG_REV_ID",
+            "PCILEECH_CFGTLP_ZERO_DATA",
+            "PCILEECH_CFGTLP_PCIE_WRITE_ENABLE"
+        )) {
+            if ($fifo -notmatch [regex]::Escape($macro)) {
+                $failures.Add("$rel/pcileech_fifo.sv missing $macro")
+            }
+        }
+    }
+
+    $cfgPath = Join-Path $dir.FullName "pcileech_pcie_cfg_a7.sv"
+    if (Test-Path $cfgPath) {
+        $cfg = Get-Content -Raw $cfgPath
+        $cfgMacros = @(
+            "PCILEECH_CFG_DSN",
+            "PCILEECH_CFGSPACE_STATUS_REGISTER_AUTO_CLEAR",
+            "PCILEECH_CFG_PM_FORCE_STATE",
+            "PCILEECH_CFG_PM_FORCE_STATE_EN",
+            "PCILEECH_CFG_PM_HALT_ASPM_L0S",
+            "PCILEECH_CFG_PM_HALT_ASPM_L1"
+        )
+        if ($cfg -match 'CFGSPACE_COMMAND_REGISTER_AUTO_SET') {
+            $cfgMacros += "PCILEECH_CFGSPACE_COMMAND_REGISTER_AUTO_SET"
+        }
+        foreach ($macro in $cfgMacros) {
+            if ($cfg -notmatch [regex]::Escape($macro)) {
+                $failures.Add("$rel/pcileech_pcie_cfg_a7.sv missing $macro")
+            }
+        }
+    }
+
+    $barPath = Join-Path $dir.FullName "pcileech_tlps128_bar_controller.sv"
+    if (Test-Path $barPath) {
+        $bar = Get-Content -Raw $barPath
+        foreach ($macro in 0..6 | ForEach-Object { "PCILEECH_BAR_IMPL_$_" }) {
+            if ($bar -notmatch [regex]::Escape($macro)) {
+                $failures.Add("$rel/pcileech_tlps128_bar_controller.sv missing $macro")
+            }
+        }
+    }
+
+    Get-ChildItem -Path $dir.FullName -Filter "*.sv" | ForEach-Object {
+        $lineNo = 0
+        foreach ($line in Get-Content $_.FullName) {
+            $lineNo++
+            $code = ($line -split '//', 2)[0]
+            if ($code -cmatch '(?<!`)PCILEECH_') {
+                $failures.Add("$rel/$($_.Name):$lineNo has a PCILEECH macro without a SystemVerilog backtick")
+            }
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    $failures | ForEach-Object { Write-Error $_ -ErrorAction Continue }
+    throw "$($failures.Count) endpoint hook checks failed"
+}
+
+Write-Host "Endpoint hook checks passed for $($srcDirs.Count) board source directories"


### PR DESCRIPTION
## Summary

- add default endpoint personality config headers for supported board source trees
- route PCIe identity, selected config-space controls, and BAR implementation selection through macros
- document the custom endpoint hook contract and add a repository check for hook coverage

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\test_endpoint_hooks.ps1`
- `git diff --cached --check`

HDL synthesis was not run locally because Vivado is not installed in this environment.